### PR TITLE
make the OpenOptions data public, to allow access to custom VFS.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,11 +162,11 @@ pub trait VFS {
 /// Options for opening files
 #[derive(Debug, Default)]
 pub struct OpenOptions {
-    read: bool,
-    write: bool,
-    create: bool,
-    append: bool,
-    truncate: bool,
+    pub read: bool,
+    pub write: bool,
+    pub create: bool,
+    pub append: bool,
+    pub truncate: bool,
 }
 
 impl OpenOptions {


### PR DESCRIPTION
I create a custom VFS implementation to access data in a 3ds rom. However, I can't access the OpenOptions options, as they are private. This PR make them public, so they can be read (and set) by libraries.