### PR TITLE
Activate `embedded-fs` feature when building on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ camino = "1.0.5"
 embedded-fs = ["rust-embed"]
 export-test-macros = []
 
+[package.metadata.docs.rs]
+features = ["embedded-fs"]


### PR DESCRIPTION
This is so `EmbeddedFs` will actually show up in the online docs.