### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,4 +65,6 @@ pub use filesystem::FileSystem;
 pub use impls::embedded::EmbeddedFS;
 pub use impls::memory::MemoryFS;
 pub use impls::physical::PhysicalFS;
+pub use impls::overlay::OverlayFS;
+pub use impls::altroot::AltrootFS;
 pub use path::*;


### PR DESCRIPTION
Currently OverlayFS and AltRoot is not added to the primary `use` path, therefore, using the lib would require an import as:
```
use vfs::{VfsPath};
use vfs::impls::overlay::OverlayFS;
```
Bringing them in here allows us to utilize the same imports as MemoryFS and PhysicalFS