### PR TITLE
Impl std::error::Error for VfsError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,16 @@ pub enum VfsError {
     NotSupported,
 }
 
+impl std::error::Error for VfsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        if let Self::WithContext { cause, .. } = self {
+            Some(cause)
+        } else {
+            None
+        }
+    }
+}
+
 impl From<String> for VfsError {
     fn from(message: String) -> Self {
         VfsError::Other { message }


### PR DESCRIPTION
This enables further compatibility with the rest of the Rust error handling ecosystem. Provides an implementation of source() that returns the nested VfsError cause if the current type is VfsError::WithContext

The original reason for this change was to make VfsError compatible with thiserror::Error, since it expects an `impl std::error::Error` for auto-generating From<T> impls