### PR TITLE
Improve error ergonomics for end users

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,10 @@ impl VfsError {
     pub fn kind(&self) -> &VfsErrorKind {
         &self.kind
     }
+
+    pub fn path(&self) -> &String {
+        &self.path
+    }
 }
 
 impl fmt::Display for VfsError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,9 @@ impl From<VfsErrorKind> for VfsError {
         let kind = match kind {
             VfsErrorKind::IoError(io) => match io.kind() {
                 io::ErrorKind::NotFound => VfsErrorKind::FileNotFound,
-                io::ErrorKind::Unsupported => VfsErrorKind::NotSupported,
+                // TODO: If MSRV changes to 1.53, enable this. Alternatively,
+                //      if it's possible to #[cfg] just this line, try that
+                // io::ErrorKind::Unsupported => VfsErrorKind::NotSupported,
                 _ => VfsErrorKind::IoError(io),
             },
             // Remaining kinda are passed through as-is

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,6 +1,7 @@
 //! The filesystem trait definitions needed to implement new virtual filesystems
 
-use crate::{SeekAndRead, VfsError, VfsMetadata, VfsPath, VfsResult};
+use crate::error::VfsErrorKind;
+use crate::{SeekAndRead, VfsMetadata, VfsPath, VfsResult};
 use std::fmt::Debug;
 use std::io::Write;
 
@@ -34,16 +35,16 @@ pub trait FileSystem: Debug + Sync + Send + 'static {
     /// Removes the directory at this path
     fn remove_dir(&self, path: &str) -> VfsResult<()>;
     /// Copies the src path to the destination path within the same filesystem (optional)
-    fn copy_file(&self, _src: &str, _dest: &str) -> VfsResult<()> {
-        Err(VfsError::NotSupported)
+    fn copy_file(&self, _src: &str, dest: &str) -> VfsResult<()> {
+        Err(VfsErrorKind::NotSupported.into())
     }
     /// Moves the src path to the destination path within the same filesystem (optional)
-    fn move_file(&self, _src: &str, _dest: &str) -> VfsResult<()> {
-        Err(VfsError::NotSupported)
+    fn move_file(&self, _src: &str, dest: &str) -> VfsResult<()> {
+        Err(VfsErrorKind::NotSupported.into())
     }
     /// Moves the src directory to the destination path within the same filesystem (optional)
-    fn move_dir(&self, _src: &str, _dest: &str) -> VfsResult<()> {
-        Err(VfsError::NotSupported)
+    fn move_dir(&self, _src: &str, dest: &str) -> VfsResult<()> {
+        Err(VfsErrorKind::NotSupported.into())
     }
 }
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -35,15 +35,15 @@ pub trait FileSystem: Debug + Sync + Send + 'static {
     /// Removes the directory at this path
     fn remove_dir(&self, path: &str) -> VfsResult<()>;
     /// Copies the src path to the destination path within the same filesystem (optional)
-    fn copy_file(&self, _src: &str, dest: &str) -> VfsResult<()> {
+    fn copy_file(&self, _src: &str, _dest: &str) -> VfsResult<()> {
         Err(VfsErrorKind::NotSupported.into())
     }
     /// Moves the src path to the destination path within the same filesystem (optional)
-    fn move_file(&self, _src: &str, dest: &str) -> VfsResult<()> {
+    fn move_file(&self, _src: &str, _dest: &str) -> VfsResult<()> {
         Err(VfsErrorKind::NotSupported.into())
     }
     /// Moves the src directory to the destination path within the same filesystem (optional)
-    fn move_dir(&self, _src: &str, dest: &str) -> VfsResult<()> {
+    fn move_dir(&self, _src: &str, _dest: &str) -> VfsResult<()> {
         Err(VfsErrorKind::NotSupported.into())
     }
 }

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -1,6 +1,6 @@
 //! A file system with its root in a particular directory of another filesystem
 
-use crate::{FileSystem, SeekAndRead, VfsError, VfsMetadata, VfsPath, VfsResult};
+use crate::{error::VfsErrorKind, FileSystem, SeekAndRead, VfsMetadata, VfsPath, VfsResult};
 use std::io::Write;
 
 /// Similar to a chroot but done purely by path manipulation
@@ -78,7 +78,7 @@ impl FileSystem for AltrootFS {
 
     fn copy_file(&self, src: &str, dest: &str) -> VfsResult<()> {
         if dest.is_empty() {
-            return Err(VfsError::NotSupported);
+            return Err(VfsErrorKind::NotSupported.into());
         }
         self.path(src)?.copy_file(&self.path(dest)?)
     }

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -227,14 +227,18 @@ mod tests {
     #[test]
     fn read_dir_on_file_err() {
         let fs = get_test_fs();
-        assert!(match fs.read_dir("/a.txt").map(|_| ()).unwrap_err().kind() {
-            VfsErrorKind::Other(message) => message == "Not a directory",
-            _ => false,
-        });
-        assert!(match fs.read_dir("/a/d.txt").map(|_| ()).unwrap_err().kind() {
-            VfsErrorKind::Other(message) => message == "Not a directory",
-            _ => false,
-        });
+        assert!(
+            match fs.read_dir("/a.txt").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::Other(message) => message == "Not a directory",
+                _ => false,
+            }
+        );
+        assert!(
+            match fs.read_dir("/a/d.txt").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::Other(message) => message == "Not a directory",
+                _ => false,
+            }
+        );
     }
 
     #[test]
@@ -363,13 +367,19 @@ mod tests {
     #[test]
     fn remove_file_not_supported() {
         let fs = get_test_fs();
-        assert!(matches!(fs.remove_file("/abc.txt").map(|_| ()).unwrap_err().kind(), VfsErrorKind::NotSupported));
+        assert!(matches!(
+            fs.remove_file("/abc.txt").map(|_| ()).unwrap_err().kind(),
+            VfsErrorKind::NotSupported
+        ));
     }
 
     #[test]
     fn remove_dir_not_supported() {
         let fs = get_test_fs();
-        assert!(matches!(fs.remove_dir("/abc.txt").map(|_| ()).unwrap_err().kind(), VfsErrorKind::NotSupported));
+        assert!(matches!(
+            fs.remove_dir("/abc.txt").map(|_| ()).unwrap_err().kind(),
+            VfsErrorKind::NotSupported
+        ));
     }
 
     #[test]

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -210,18 +210,22 @@ mod tests {
     #[test]
     fn read_dir_no_directory_err() {
         let fs = get_test_fs();
-        assert!(matches!(
-            fs.read_dir("/c/f").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::FileNotFound
-        ));
-        assert!(matches!(
-            fs.read_dir("/a.txt.").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::FileNotFound
-        ));
-        assert!(matches!(
-            fs.read_dir("/abc/def/ghi").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::FileNotFound
-        ));
+        assert!(match fs.read_dir("/c/f").map(|_| ()).unwrap_err().kind() {
+            VfsErrorKind::FileNotFound => true,
+            _ => false,
+        });
+        assert!(
+            match fs.read_dir("/a.txt.").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::FileNotFound => true,
+                _ => false,
+            }
+        );
+        assert!(
+            match fs.read_dir("/abc/def/ghi").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::FileNotFound => true,
+                _ => false,
+            }
+        );
     }
 
     #[test]
@@ -244,10 +248,12 @@ mod tests {
     #[test]
     fn create_dir_not_supported() {
         let fs = get_test_fs();
-        assert!(matches!(
-            fs.create_dir("/abc").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::NotSupported
-        ))
+        assert!(
+            match fs.create_dir("/abc").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::NotSupported => true,
+                _ => false,
+            }
+        )
     }
 
     #[test]
@@ -278,15 +284,24 @@ mod tests {
         // FIXME: These tests have been weakened since the FS implementations aren't intended to
         //      provide paths for errors. Maybe this could be handled better
         assert!(match fs.open_file("/") {
-            Err(err) => matches!(err.kind(), VfsErrorKind::FileNotFound),
+            Err(err) => match err.kind() {
+                VfsErrorKind::FileNotFound => true,
+                _ => false,
+            },
             _ => false,
         });
         assert!(match fs.open_file("/abc.txt") {
-            Err(err) => matches!(err.kind(), VfsErrorKind::FileNotFound),
+            Err(err) => match err.kind() {
+                VfsErrorKind::FileNotFound => true,
+                _ => false,
+            },
             _ => false,
         });
         assert!(match fs.open_file("/c/f.txt") {
-            Err(err) => matches!(err.kind(), VfsErrorKind::FileNotFound),
+            Err(err) => match err.kind() {
+                VfsErrorKind::FileNotFound => true,
+                _ => false,
+            },
             _ => false,
         });
     }
@@ -294,19 +309,23 @@ mod tests {
     #[test]
     fn create_file_not_supported() {
         let fs = get_test_fs();
-        assert!(matches!(
-            fs.create_file("/abc.txt").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::NotSupported
-        ));
+        assert!(
+            match fs.create_file("/abc.txt").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::NotSupported => true,
+                _ => false,
+            }
+        );
     }
 
     #[test]
     fn append_file_not_supported() {
         let fs = get_test_fs();
-        assert!(matches!(
-            fs.append_file("/abc.txt").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::NotSupported
-        ));
+        assert!(
+            match fs.append_file("/abc.txt").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::NotSupported => true,
+                _ => false,
+            }
+        );
     }
 
     #[test]
@@ -342,7 +361,10 @@ mod tests {
     fn metadata_not_found() {
         let fs = get_test_fs();
         assert!(match fs.metadata("/abc.txt") {
-            Err(err) => matches!(err.kind(), VfsErrorKind::FileNotFound),
+            Err(err) => match err.kind() {
+                VfsErrorKind::FileNotFound => true,
+                _ => false,
+            },
             _ => false,
         });
     }
@@ -367,19 +389,23 @@ mod tests {
     #[test]
     fn remove_file_not_supported() {
         let fs = get_test_fs();
-        assert!(matches!(
-            fs.remove_file("/abc.txt").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::NotSupported
-        ));
+        assert!(
+            match fs.remove_file("/abc.txt").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::NotSupported => true,
+                _ => false,
+            }
+        );
     }
 
     #[test]
     fn remove_dir_not_supported() {
         let fs = get_test_fs();
-        assert!(matches!(
-            fs.remove_dir("/abc.txt").map(|_| ()).unwrap_err().kind(),
-            VfsErrorKind::NotSupported
-        ));
+        assert!(
+            match fs.remove_dir("/abc.txt").map(|_| ()).unwrap_err().kind() {
+                VfsErrorKind::NotSupported => true,
+                _ => false,
+            }
+        );
     }
 
     #[test]

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -162,7 +162,7 @@ impl FileSystem for MemoryFS {
     fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead>> {
         let handle = self.handle.read().unwrap();
         let file = handle.files.get(path).ok_or(VfsErrorKind::FileNotFound)?;
-        ensure_file(path, file)?;
+        ensure_file(file)?;
         Ok(Box::new(ReadableFile {
             content: file.content.clone(),
             position: 0,
@@ -356,7 +356,7 @@ mod tests {
     }
 }
 
-fn ensure_file(path: &str, file: &MemoryFile) -> VfsResult<()> {
+fn ensure_file(file: &MemoryFile) -> VfsResult<()> {
     if file.file_type != VfsFileType::File {
         return Err(VfsErrorKind::Other("Not a file".into()).into());
     }

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -1,8 +1,9 @@
 //! A "physical" file system implementation using the underlying OS file system
 
+use crate::error::VfsErrorKind;
+use crate::VfsResult;
 use crate::{FileSystem, VfsMetadata};
 use crate::{SeekAndRead, VfsFileType};
-use crate::{VfsError, VfsResult};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -97,6 +98,7 @@ impl FileSystem for PhysicalFS {
 
     fn move_file(&self, src: &str, dest: &str) -> VfsResult<()> {
         std::fs::rename(self.get_path(src), self.get_path(dest))?;
+
         Ok(())
     }
 
@@ -104,7 +106,7 @@ impl FileSystem for PhysicalFS {
         let result = std::fs::rename(self.get_path(src), self.get_path(dest));
         if result.is_err() {
             // Error possibly due to different filesystems, return not supported and let the fallback handle it
-            return Err(VfsError::NotSupported);
+            return Err(VfsErrorKind::NotSupported.into());
         }
         Ok(())
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -172,10 +172,10 @@ impl VfsPath {
     /// ```
     pub fn create_dir(&self) -> VfsResult<()> {
         self.get_parent("create directory")?;
-        self.fs
-            .fs
-            .create_dir(&self.path)
-            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not create directory"))
+        self.fs.fs.create_dir(&self.path).map_err(|err| {
+            err.with_path(&self.path)
+                .with_context(|| "Could not create directory")
+        })
     }
 
     /// Creates the directory at this path, also creating parent directories as necessary
@@ -268,10 +268,10 @@ impl VfsPath {
     /// ```
     pub fn create_file(&self) -> VfsResult<Box<dyn Write>> {
         self.get_parent("create file")?;
-        self.fs
-            .fs
-            .create_file(&self.path)
-            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not create file"))
+        self.fs.fs.create_file(&self.path).map_err(|err| {
+            err.with_path(&self.path)
+                .with_context(|| "Could not create file")
+        })
     }
 
     /// Opens the file at this path for reading
@@ -290,10 +290,10 @@ impl VfsPath {
     /// # Ok::<(), VfsError>(())
     /// ```
     pub fn open_file(&self) -> VfsResult<Box<dyn SeekAndRead>> {
-        self.fs
-            .fs
-            .open_file(&self.path)
-            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not open file"))
+        self.fs.fs.open_file(&self.path).map_err(|err| {
+            err.with_path(&self.path)
+                .with_context(|| "Could not open file")
+        })
     }
 
     /// Checks whether parent is a directory
@@ -343,10 +343,10 @@ impl VfsPath {
     /// # Ok::<(), VfsError>(())
     /// ```
     pub fn append_file(&self) -> VfsResult<Box<dyn Write>> {
-        self.fs
-            .fs
-            .append_file(&self.path)
-            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not open file for appending"))
+        self.fs.fs.append_file(&self.path).map_err(|err| {
+            err.with_path(&self.path)
+                .with_context(|| "Could not open file for appending")
+        })
     }
 
     /// Removes the file at this path
@@ -365,10 +365,10 @@ impl VfsPath {
     /// # Ok::<(), VfsError>(())
     /// ```
     pub fn remove_file(&self) -> VfsResult<()> {
-        self.fs
-            .fs
-            .remove_file(&self.path)
-            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not remove file"))
+        self.fs.fs.remove_file(&self.path).map_err(|err| {
+            err.with_path(&self.path)
+                .with_context(|| "Could not remove file")
+        })
     }
 
     /// Removes the directory at this path

--- a/src/path.rs
+++ b/src/path.rs
@@ -673,9 +673,12 @@ impl VfsPath {
             if Arc::ptr_eq(&self.fs, &destination.fs) {
                 let result = self.fs.fs.copy_file(&self.path, &destination.path);
                 match result {
-                    Err(err) if matches!(err.kind(), VfsErrorKind::NotSupported) => {
-                        // continue
-                    }
+                    Err(err) => match err.kind() {
+                        VfsErrorKind::NotSupported => {
+                            // continue
+                        }
+                        _ => return Err(err),
+                    },
                     other => return other,
                 }
             }
@@ -729,9 +732,12 @@ impl VfsPath {
             if Arc::ptr_eq(&self.fs, &destination.fs) {
                 let result = self.fs.fs.move_file(&self.path, &destination.path);
                 match result {
-                    Err(err) if matches!(err.kind(), VfsErrorKind::NotSupported) => {
-                        // continue
-                    }
+                    Err(err) => match err.kind() {
+                        VfsErrorKind::NotSupported => {
+                            // continue
+                        }
+                        _ => return Err(err),
+                    },
                     other => return other,
                 }
             }
@@ -840,9 +846,12 @@ impl VfsPath {
             if Arc::ptr_eq(&self.fs, &destination.fs) {
                 let result = self.fs.fs.move_dir(&self.path, &destination.path);
                 match result {
-                    Err(err) if matches!(err.kind(), VfsErrorKind::NotSupported) => {
-                        // continue
-                    }
+                    Err(err) => match err.kind() {
+                        VfsErrorKind::NotSupported => {
+                            // continue
+                        }
+                        _ => return Err(err),
+                    },
                     other => return other,
                 }
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -175,7 +175,7 @@ impl VfsPath {
         self.fs
             .fs
             .create_dir(&self.path)
-            .map_err(|err| err.with_context(|| "Could not create directory"))
+            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not create directory"))
     }
 
     /// Creates the directory at this path, also creating parent directories as necessary
@@ -271,7 +271,7 @@ impl VfsPath {
         self.fs
             .fs
             .create_file(&self.path)
-            .map_err(|err| err.with_context(|| "Could not create file"))
+            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not create file"))
     }
 
     /// Opens the file at this path for reading
@@ -293,7 +293,7 @@ impl VfsPath {
         self.fs
             .fs
             .open_file(&self.path)
-            .map_err(|err| err.with_context(|| "Could not open file"))
+            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not open file"))
     }
 
     /// Checks whether parent is a directory
@@ -346,7 +346,7 @@ impl VfsPath {
         self.fs
             .fs
             .append_file(&self.path)
-            .map_err(|err| err.with_context(|| "Could not open file for appending"))
+            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not open file for appending"))
     }
 
     /// Removes the file at this path
@@ -368,7 +368,7 @@ impl VfsPath {
         self.fs
             .fs
             .remove_file(&self.path)
-            .map_err(|err| err.with_context(|| "Could not remove file"))
+            .map_err(|err| err.with_path(&self.path).with_context(|| "Could not remove file"))
     }
 
     /// Removes the directory at this path
@@ -689,7 +689,7 @@ impl VfsPath {
             Ok(())
         }()
         .map_err(|err| {
-            err.with_context(|| {
+            err.with_path(&self.path).with_context(|| {
                 format!(
                     "Could not copy '{}' to '{}'",
                     self.as_str(),
@@ -746,7 +746,7 @@ impl VfsPath {
             Ok(())
         }()
         .map_err(|err| {
-            err.with_context(|| {
+            err.with_path(&self.path).with_context(|| {
                 format!(
                     "Could not move '{}' to '{}'",
                     self.as_str(),
@@ -800,7 +800,7 @@ impl VfsPath {
             Ok(())
         }()
         .map_err(|err| {
-            err.with_context(|| {
+            err.with_path(&self.path).with_context(|| {
                 format!(
                     "Could not copy directory '{}' to '{}'",
                     self.as_str(),
@@ -861,7 +861,7 @@ impl VfsPath {
             Ok(())
         }()
         .map_err(|err| {
-            err.with_context(|| {
+            err.with_path(&self.path).with_context(|| {
                 format!(
                     "Could not move directory '{}' to '{}'",
                     self.as_str(),


### PR DESCRIPTION
Allows end users of VFS to match against ErrorKind directly without having
to drill down through the WithContext variant

Also offers a normalization for I/O errors to ensure the corresponding
VFS Error kind is used rather than a generic I/O Error

Fixes #33 