### PR TITLE
Add `Send` to trait objects returned from APIs, for interoperability with async code

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -21,11 +21,11 @@ pub trait FileSystem: Debug + Sync + Send + 'static {
     /// Note that the parent directory must already exist.
     fn create_dir(&self, path: &str) -> VfsResult<()>;
     /// Opens the file at this path for reading
-    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead>>;
+    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>>;
     /// Creates a file at this path for writing
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write>>;
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>>;
     /// Opens the file at this path for appending
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write>>;
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>>;
     /// Returns the file metadata for the file at this path
     fn metadata(&self, path: &str) -> VfsResult<VfsMetadata>;
     /// Returns true if a file or directory at path exists, false otherwise

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -46,15 +46,15 @@ impl FileSystem for AltrootFS {
         self.path(path)?.create_dir()
     }
 
-    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead>> {
+    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>> {
         self.path(path)?.open_file()
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         self.path(path)?.create_file()
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         self.path(path)?.append_file()
     }
 

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -99,18 +99,18 @@ where
         Err(VfsErrorKind::NotSupported.into())
     }
 
-    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead>> {
+    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>> {
         match T::get(path.split_at(1).1) {
             None => Err(VfsErrorKind::FileNotFound.into()),
             Some(file) => Ok(Box::new(Cursor::new(file.data))),
         }
     }
 
-    fn create_file(&self, _path: &str) -> VfsResult<Box<dyn Write>> {
+    fn create_file(&self, _path: &str) -> VfsResult<Box<dyn Write + Send>> {
         Err(VfsErrorKind::NotSupported.into())
     }
 
-    fn append_file(&self, _path: &str) -> VfsResult<Box<dyn Write>> {
+    fn append_file(&self, _path: &str) -> VfsResult<Box<dyn Write + Send>> {
         Err(VfsErrorKind::NotSupported.into())
     }
 

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -159,7 +159,7 @@ impl FileSystem for MemoryFS {
         Ok(())
     }
 
-    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead>> {
+    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>> {
         let handle = self.handle.read().unwrap();
         let file = handle.files.get(path).ok_or(VfsErrorKind::FileNotFound)?;
         ensure_file(file)?;
@@ -169,7 +169,7 @@ impl FileSystem for MemoryFS {
         }))
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         self.ensure_has_parent(path)?;
         let content = Arc::new(Vec::<u8>::new());
         self.handle.write().unwrap().files.insert(
@@ -187,7 +187,7 @@ impl FileSystem for MemoryFS {
         Ok(Box::new(writer))
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         let handle = self.handle.write().unwrap();
         let file = handle.files.get(path).ok_or(VfsErrorKind::FileNotFound)?;
         let mut content = Cursor::new(file.content.as_ref().clone());

--- a/src/impls/overlay.rs
+++ b/src/impls/overlay.rs
@@ -117,11 +117,11 @@ impl FileSystem for OverlayFS {
         Ok(())
     }
 
-    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead>> {
+    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>> {
         self.read_path(path)?.open_file()
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         self.ensure_has_parent(path)?;
         let result = self.write_path(path)?.create_file()?;
         let whiteout_path = self.whiteout_path(path)?;
@@ -131,7 +131,7 @@ impl FileSystem for OverlayFS {
         Ok(result)
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         let write_path = self.write_path(path)?;
         if !write_path.exists()? {
             self.ensure_has_parent(path)?;

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -45,15 +45,15 @@ impl FileSystem for PhysicalFS {
         Ok(())
     }
 
-    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead>> {
+    fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>> {
         Ok(Box::new(File::open(self.get_path(path))?))
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         Ok(Box::new(File::create(self.get_path(path))?))
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
         Ok(Box::new(
             OpenOptions::new()
                 .write(true)

--- a/src/path.rs
+++ b/src/path.rs
@@ -266,7 +266,7 @@ impl VfsPath {
     /// assert_eq!(&result, "Hello, world!");
     /// # Ok::<(), VfsError>(())
     /// ```
-    pub fn create_file(&self) -> VfsResult<Box<dyn Write>> {
+    pub fn create_file(&self) -> VfsResult<Box<dyn Write + Send>> {
         self.get_parent("create file")?;
         self.fs.fs.create_file(&self.path).map_err(|err| {
             err.with_path(&self.path)
@@ -289,7 +289,7 @@ impl VfsPath {
     /// assert_eq!(&result, "Hello, world!");
     /// # Ok::<(), VfsError>(())
     /// ```
-    pub fn open_file(&self) -> VfsResult<Box<dyn SeekAndRead>> {
+    pub fn open_file(&self) -> VfsResult<Box<dyn SeekAndRead + Send>> {
         self.fs.fs.open_file(&self.path).map_err(|err| {
             err.with_path(&self.path)
                 .with_context(|| "Could not open file")
@@ -342,7 +342,7 @@ impl VfsPath {
     /// assert_eq!(&result, "Hello, world!");
     /// # Ok::<(), VfsError>(())
     /// ```
-    pub fn append_file(&self) -> VfsResult<Box<dyn Write>> {
+    pub fn append_file(&self) -> VfsResult<Box<dyn Write + Send>> {
         self.fs.fs.append_file(&self.path).map_err(|err| {
             err.with_path(&self.path)
                 .with_context(|| "Could not open file for appending")


### PR DESCRIPTION
Previously, these APIs would return a trait object not marked Send, which made it difficult to use in an async context.

Adding 'Send' requires very little modification (though I think this should still be a major version bump because it affects a public trait) and greatly improves usability for async code.