### PR TITLE
Allow multiple consecutive slashes in paths (but see discussion)

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -108,11 +108,11 @@ impl VfsPath {
         }
         let mut new_components: Vec<&str> = vec![];
         let mut base_path = self.clone();
+        if path.ends_with('/') {
+            return Err(VfsError::from(VfsErrorKind::InvalidPath).with_path(path));
+        }
         for component in path.split('/') {
-            if component.is_empty() {
-                return Err(VfsError::from(VfsErrorKind::InvalidPath).with_path(path));
-            }
-            if component == "." {
+            if component == "." || component.is_empty() {
                 continue;
             }
             if component == ".." {

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -320,6 +320,7 @@ macro_rules! test_vfs {
                 assert_eq!(root.join("foo").unwrap().join("").unwrap().as_str(), "/foo");
                 assert_eq!(root.join("foo").unwrap().as_str(), "/foo");
                 assert_eq!(root.join("foo/bar").unwrap().as_str(), "/foo/bar");
+                assert_eq!(root.join("foo/////bar").unwrap().as_str(), "/foo/bar");
                 assert_eq!(root.join("foo/bar/baz").unwrap().as_str(), "/foo/bar/baz");
                 assert_eq!(
                     root.join("foo").unwrap().join("bar").unwrap().as_str(),


### PR DESCRIPTION
Partially addresses https://github.com/manuel-woelker/rust-vfs/issues/42

Discussion:
So, I'm unsure of how a slash at the end should be handled. On one hand, it seems weird that you can refer to a file like `dir/file.txt/`, but you can already do `dir/file.txt/.`  

Both seem a bit weird, I don't know how you would solve that. I guess for consistencies sake, you should allow both

Thoughts?