### PR TITLE
VfsPath: Add 'is_root()` method

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -153,6 +153,20 @@ impl VfsPath {
         }
     }
 
+    /// Returns true if this is the root path
+    ///
+    /// ```
+    /// # use vfs::{MemoryFS, VfsError, VfsFileType, VfsPath};
+    /// let path = VfsPath::new(MemoryFS::new());
+    /// assert!(path.is_root());
+    /// let path = path.join("foo/bar")?;
+    /// assert!(! path.is_root());
+    /// # Ok::<(), VfsError>(())
+    /// ```
+    pub fn is_root(&self) -> bool {
+        self.path.is_empty()
+    }
+
     /// Creates the directory at this path
     ///
     /// Note that the parent directory must exist.


### PR DESCRIPTION
This new method allows checking if a path is root without cloning or constructing anything.

Currently, I believe you have to do either:
* `path.as_str().is_empty()` which is less semantically obvious and exposes the implementation
* `path == path.root()` which is a bit more expensive because cloning an `Arc` requires atomic operations.

Previously, you could also do:
* `path.parent().is_none()` which had similar issues to `path == path.root()`