### PR TITLE
Allow absolute paths in VfsPath::join(), fix bug

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -107,8 +107,13 @@ impl VfsPath {
             return Ok(self.clone());
         }
         let mut new_components: Vec<&str> = vec![];
-        let mut base_path = self.clone();
-        if path.ends_with('/') {
+        let mut base_path = if path.starts_with('/') {
+            self.root()
+        } else {
+            self.clone()
+        };
+        // Prevent paths from ending in slashes unless this is just the root directory.
+        if path.len() > 1 && path.ends_with('/') {
             return Err(VfsError::from(VfsErrorKind::InvalidPath).with_path(path));
         }
         for component in path.split('/') {

--- a/src/path.rs
+++ b/src/path.rs
@@ -124,7 +124,7 @@ impl VfsPath {
                 if !new_components.is_empty() {
                     new_components.truncate(new_components.len() - 1);
                 } else {
-                    base_path = self.parent();
+                    base_path = base_path.parent();
                 }
             } else {
                 new_components.push(component);

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -388,6 +388,11 @@ macro_rules! test_vfs {
                 assert_eq!(root.join("/").unwrap(), root);
                 assert_eq!(root.join("foo/bar").unwrap().join("/baz").unwrap(), root.join("baz").unwrap());
 
+                assert_eq!(
+                    root.join("/foo/bar/baz").unwrap().join("../../..").unwrap(),
+                    root
+                );
+
                 /// Utility function for templating the same error message
                 fn invalid_path_message(path: &str) -> String {
                     format!("An error occured for '{}': The path is invalid", path)
@@ -1116,6 +1121,11 @@ macro_rules! test_vfs_readonly {
                 assert_eq!(
                     root.join("foo/bar").unwrap().join("/baz").unwrap(),
                     root.join("baz").unwrap()
+                );
+
+                assert_eq!(
+                    root.join("/foo/bar/baz").unwrap().join("../../..").unwrap(),
+                    root
                 );
 
                 /// Utility function for templating the same error message

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -385,16 +385,14 @@ macro_rules! test_vfs {
                     root.join("foo").unwrap()
                 );
 
+                assert_eq!(root.join("/").unwrap(), root);
+                assert_eq!(root.join("foo/bar").unwrap().join("/baz").unwrap(), root.join("baz").unwrap());
+
                 /// Utility function for templating the same error message
                 fn invalid_path_message(path: &str) -> String {
                     format!("An error occured for '{}': The path is invalid", path)
                 }
 
-                assert_eq!(
-                    root.join("/").unwrap_err().to_string(),
-                    invalid_path_message("/"),
-                    "/"
-                );
                 assert_eq!(
                     root.join("foo/").unwrap_err().to_string(),
                     invalid_path_message("foo/"),
@@ -1114,17 +1112,18 @@ macro_rules! test_vfs_readonly {
                 assert_eq!(root.join("..").unwrap(), root);
                 assert_eq!(root.join("../foo").unwrap(), root.join("foo").unwrap());
 
+                assert_eq!(root.join("/").unwrap(), root);
+                assert_eq!(
+                    root.join("foo/bar").unwrap().join("/baz").unwrap(),
+                    root.join("baz").unwrap()
+                );
+
                 /// Utility function for templating the same error message
                 // TODO: Maybe deduplicate this function
                 fn invalid_path_message(path: &str) -> String {
                     format!("An error occured for '{}': The path is invalid", path)
                 }
 
-                assert_eq!(
-                    root.join("/").unwrap_err().to_string(),
-                    invalid_path_message("/"),
-                    "/"
-                );
                 assert_eq!(
                     root.join("foo/").unwrap_err().to_string(),
                     invalid_path_message("foo/"),


### PR DESCRIPTION
Closes https://github.com/manuel-woelker/rust-vfs/issues/42

Can now do:
`path.join("/")` or `path.join("foo/bar/baz")`

This also fixes a bug where ".." would not behave correctly