### PR TITLE
Have `read_dir` and `walk_dir` return `Send`

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 pub trait FileSystem: Debug + Sync + Send + 'static {
     /// Iterates over all direct children of this directory path
     /// NOTE: the returned String items denote the local bare filenames, i.e. they should not contain "/" anywhere
-    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String>>>;
+    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String> + Send>>;
     /// Creates the directory at this path
     ///
     /// Note that the parent directory must already exist.

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -35,11 +35,11 @@ impl AltrootFS {
 }
 
 impl FileSystem for AltrootFS {
-    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String>>> {
+    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String> + Send>> {
         self.path(path)?
             .read_dir()
             .map(|result| result.map(|path| path.filename()))
-            .map(|entries| Box::new(entries) as Box<dyn Iterator<Item = String>>)
+            .map(|entries| Box::new(entries) as Box<dyn Iterator<Item = String> + Send>)
     }
 
     fn create_dir(&self, path: &str) -> VfsResult<()> {

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -80,7 +80,7 @@ impl<T> FileSystem for EmbeddedFS<T>
 where
     T: RustEmbed + Send + Sync + Debug + 'static,
 {
-    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String>>> {
+    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String> + Send>> {
         let normalized_path = normalize_path(path)?;
         if let Some(children) = self.directory_map.get(normalized_path) {
             Ok(Box::new(

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -120,7 +120,7 @@ impl Seek for ReadableFile {
 }
 
 impl FileSystem for MemoryFS {
-    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String>>> {
+    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String> + Send>> {
         let prefix = format!("{}/", path);
         let handle = self.handle.read().unwrap();
         let mut found_directory = false;

--- a/src/impls/overlay.rs
+++ b/src/impls/overlay.rs
@@ -80,7 +80,7 @@ impl OverlayFS {
 }
 
 impl FileSystem for OverlayFS {
-    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String>>> {
+    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String> + Send>> {
         let actual_path = if !path.is_empty() { &path[1..] } else { path };
         if !self.read_path(path)?.exists()? {
             return Err(VfsErrorKind::FileNotFound.into());

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -31,7 +31,7 @@ impl PhysicalFS {
 }
 
 impl FileSystem for PhysicalFS {
-    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String>>> {
+    fn read_dir(&self, path: &str) -> VfsResult<Box<dyn Iterator<Item = String> + Send>> {
         let entries = Box::new(
             self.get_path(path)
                 .read_dir()?

--- a/src/path.rs
+++ b/src/path.rs
@@ -245,7 +245,7 @@ impl VfsPath {
     /// assert_eq!(directories, vec![path.join("bar")?, path.join("foo")?]);
     /// # Ok::<(), VfsError>(())
     /// ```
-    pub fn read_dir(&self) -> VfsResult<Box<dyn Iterator<Item = VfsPath>>> {
+    pub fn read_dir(&self) -> VfsResult<Box<dyn Iterator<Item = VfsPath> + Send>> {
         let parent = self.path.clone();
         let fs = self.fs.clone();
         Ok(Box::new(
@@ -888,7 +888,7 @@ impl VfsPath {
 /// An iterator for recursively walking a file hierarchy
 pub struct WalkDirIterator {
     /// the path iterator of the current directory
-    inner: Box<dyn Iterator<Item = VfsPath>>,
+    inner: Box<dyn Iterator<Item = VfsPath> + Send>,
     /// stack of subdirectories still to walk
     todo: Vec<VfsPath>,
 }


### PR DESCRIPTION
Previously, VfsPath::read_dir and VfsPath::walk_dir could not be held across an await. This is an inconvenience when working with async code.