### PR TITLE
Use semver instead of fixed minor ver for rust-embed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ edition = "2018"
 travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
 
 [dependencies]
-rust-embed = { version = "6.3.*", optional = true }
-rust-embed-impl = { version = "6.2.*", optional = true }
+rust-embed = { version = "^6.3.0", optional = true }
 
 [dev-dependencies]
 uuid = { version = "=0.8.1", features = ["v4"] }
@@ -22,7 +21,7 @@ camino = "1.0.5"
 anyhow = "1.0.58"
 
 [features]
-embedded-fs = ["rust-embed", "rust-embed-impl"]
+embedded-fs = ["rust-embed"]
 export-test-macros = []
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Also removes explicit dependency on rust-embed-impl, which is a transitive dependency of rust-embed (I couldn't find any references to it in this crate).

I am trying to use rust-vfs with a newer version of rust-embed but the `6.3.*` specifier prevents this. Presumably this was meant to be a minimum version number, not hard lock, so I tried to change to the semver syntax for that.