### PR TITLE
Unblock CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
 
 [dependencies]
 rust-embed = { version = "6.3.*", optional = true }
+# These versions are specified to not break MSRV 1.40
 rust-embed-impl = { version = "6.2.*", optional = true }
+rust-embed-utils = { version = "7.3.*", optional = true }
 
 [dev-dependencies]
 uuid = { version = "=0.8.1", features = ["v4"] }
@@ -22,7 +24,7 @@ camino = "1.0.5"
 anyhow = "1.0.58"
 
 [features]
-embedded-fs = ["rust-embed", "rust-embed-impl"]
+embedded-fs = ["rust-embed", "rust-embed-impl", "rust-embed-utils"]
 export-test-macros = []
 
 [package.metadata.docs.rs]

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -595,7 +595,7 @@ macro_rules! test_vfs {
             fn read_to_string_nonutf8() -> VfsResult<()> {
                 let root = create_root();
                 let path = root.join("foobar.txt")?;
-                path.create_file()?.write_all(&vec![0, 159, 146, 150])?;
+                path.create_file()?.write_all(&[0, 159, 146, 150])?;
                 let error_message = path.read_to_string().expect_err("read_to_string").to_string();
                 assert_eq!(
                     &error_message,


### PR DESCRIPTION
rust-embed-utils 7.5.0 breaks MSRV 1.40 with a feature introduced in MSRV 1.41 (`Result::map_or`)