### PR TITLE
Bump MSRV to 1.56 and Rust edition to 2021

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ jobs:
                     - stable
                     - beta
                     - nightly
-                    - 1.40.0  # MSRV
+                    - 1.56.0  # MSRV
 
         steps:
             - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Manuel Woelker <github@manuel.woelker.org>"]
 description = "A virtual filesystem for Rust"
 repository = "https://github.com/manuel-woelker/rust-vfs"
 readme = "README.md"
-keywords = ["vfs", "virtual",  "filesystem"]
+keywords = ["vfs", "virtual", "filesystem"]
 license = "Apache-2.0"
-edition = "2018"
+rust-version = "1.56"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
 
 [dependencies]
-rust-embed = { version = "6.3.*", optional = true }
-rust-embed-impl = { version = "6.2.*", optional = true }
+rust-embed = { version = "6.3.0", optional = true }
 
 [dev-dependencies]
 uuid = { version = "=0.8.1", features = ["v4"] }
@@ -22,7 +22,7 @@ camino = "1.0.5"
 anyhow = "1.0.58"
 
 [features]
-embedded-fs = ["rust-embed", "rust-embed-impl"]
+embedded-fs = ["rust-embed"]
 export-test-macros = []
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crate](https://img.shields.io/crates/v/vfs.svg)](https://crates.io/crates/vfs)
 [![API](https://docs.rs/vfs/badge.svg)](https://docs.rs/vfs)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.40.0+-green.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.56.0+-green.svg)
 [![Actions Status](https://github.com/manuel-woelker/rust-vfs/workflows/Continuous%20integration/badge.svg)](https://github.com/manuel-woelker/rust-vfs/actions?query=workflow%3A%22Continuous+integration%22)
 [![Build Status](https://travis-ci.org/manuel-woelker/rust-vfs.svg?branch=master)](https://travis-ci.org/manuel-woelker/rust-vfs)
 
@@ -18,7 +18,7 @@ This crate currently has the following implementations:
  * **OverlayFS** - an overlay file system combining two filesystems, an upper layer with read/write access and a lower layer with only read access
  * **EmbeddedFS** - a read-only file system embedded in the executable, requires `embedded-fs` feature
  
-The minimum supported Rust version is 1.40.0.
+The minimum supported Rust version is 1.56.0.
  
 Comments and pull-requests welcome!
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,9 +26,7 @@ impl From<VfsErrorKind> for VfsError {
         let kind = match kind {
             VfsErrorKind::IoError(io) => match io.kind() {
                 io::ErrorKind::NotFound => VfsErrorKind::FileNotFound,
-                // TODO: If MSRV changes to 1.53, enable this. Alternatively,
-                //      if it's possible to #[cfg] just this line, try that
-                // io::ErrorKind::Unsupported => VfsErrorKind::NotSupported,
+                io::ErrorKind::Unsupported => VfsErrorKind::NotSupported,
                 _ => VfsErrorKind::IoError(io),
             },
             // Remaining kinda are passed through as-is

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -22,13 +22,12 @@ impl AltrootFS {
 }
 
 impl AltrootFS {
-    #[allow(clippy::manual_strip)] // strip prefix manually for MSRV 1.32
     fn path(&self, path: &str) -> VfsResult<VfsPath> {
         if path.is_empty() {
             return Ok(self.root.clone());
         }
-        if path.starts_with('/') {
-            return self.root.join(&path[1..]);
+        if let Some(path) = path.strip_prefix('/') {
+            return self.root.join(path);
         }
         self.root.join(path)
     }

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -595,7 +595,7 @@ macro_rules! test_vfs {
             fn read_to_string_nonutf8() -> VfsResult<()> {
                 let root = create_root();
                 let path = root.join("foobar.txt")?;
-                path.create_file()?.write_all(&vec![0, 159, 146, 150])?;
+                path.create_file()?.write_all(&[0, 159, 146, 150])?;
                 let error_message = path.read_to_string().expect_err("read_to_string").to_string();
                 assert_eq!(
                     &error_message,


### PR DESCRIPTION
Alternative to https://github.com/manuel-woelker/rust-vfs/pull/52  

Rust 1.40 is quite old