### PR TITLE
Bump rust-embed version to 8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
 
 [dependencies]
 rust-embed = { version = "8.0.*", optional = true }
-rust-embed-impl = { version = "8.0.*", optional = true }
 async-std = { version = "1.12.0", optional = true }
 async-trait = { version = "0.1.73", optional = true}
 tokio = { version = "=1.29.0", features = ["macros", "rt"], optional = true}
@@ -28,7 +27,7 @@ anyhow = "1.0.58"
 tokio-test = "0.4.3"
 
 [features]
-embedded-fs = ["rust-embed", "rust-embed-impl"]
+embedded-fs = ["rust-embed"]
 async-vfs = ["tokio", "async-std", "async-trait", "futures", "async-recursion"]
 export-test-macros = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
 
 [dependencies]
-rust-embed = { version = "6.3.*", optional = true }
-rust-embed-impl = { version = "6.2.*", optional = true }
+rust-embed = { version = "8.0.*", optional = true }
+rust-embed-impl = { version = "8.0.*", optional = true }
 async-std = { version = "1.12.0", optional = true }
 async-trait = { version = "0.1.73", optional = true}
 tokio = { version = "=1.29.0", features = ["macros", "rt"], optional = true}


### PR DESCRIPTION
Bumps the rust-embed and rust-embed-impl crate dependencies to `8.0.*`.

From what I could tell, there hasn't there been any major changes to the rust-embed that would break things, and tests seemed to pass just fine.