### PR TITLE
Unlocked tokio crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
 rust-embed = { version = "8.0.*", optional = true }
 async-std = { version = "1.12.0", optional = true }
 async-trait = { version = "0.1.73", optional = true}
-tokio = { version = "=1.29.0", features = ["macros", "rt"], optional = true}
+tokio = { version = "1.29.0", features = ["macros", "rt"], optional = true}
 futures = {version = "0.3.28", optional = true}
 async-recursion = {version = "1.0.5", optional = true}
 


### PR DESCRIPTION
# Summary 
Initial version lock of tokio to `1.29` seems to unnecessary and means that asyc-vfs does not work in code bases that require newer versions of tokio, which is quite likely.

