### PR TITLE
use Arc<str> for paths

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -616,7 +616,6 @@ impl VfsPath {
     pub fn parent(&self) -> Self {
         let parent_path = self.parent_internal(&self.path);
         Self {
-            // path: parent_path,
             path: Arc::from(parent_path),
             fs: self.fs.clone(),
         }


### PR DESCRIPTION
Reduced usage of `memcpy` and `RtlAllocateHeap` in one of my project's using `vfs` from 9.19% and 9.19%, to 7.98% and 7.47% respectively. I saw about a 6% speed improvement, going from a full execution time of 48.96s to 46.21.

Didn't require any changes to my project as a consumer