### PR TITLE
feat: allow vfs implementations to specify m/b/a-times in file metadata

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ jobs:
                     - stable
                     - beta
                     - nightly
-                    - 1.75.0  # MSRV
+                    - 1.63.0  # MSRV
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ jobs:
                     - stable
                     - beta
                     - nightly
-                    - 1.63.0  # MSRV
+                    - 1.75.0  # MSRV
 
         steps:
             - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 keywords = ["vfs", "virtual", "filesystem", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75"
 
 [badges]
 travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
@@ -20,6 +19,8 @@ async-trait = { version = "0.1.73", optional = true}
 tokio = { version = "1.29.0", features = ["macros", "rt"], optional = true}
 futures = {version = "0.3.28", optional = true}
 async-recursion = {version = "1.0.5", optional = true}
+filetime = "0.2.23"
+camino = { version = "1.0.5", optional = true }
 
 [dev-dependencies]
 uuid = { version = "=0.8.1", features = ["v4"] }
@@ -30,7 +31,7 @@ tokio-test = "0.4.3"
 [features]
 embedded-fs = ["rust-embed"]
 async-vfs = ["tokio", "async-std", "async-trait", "futures", "async-recursion"]
-export-test-macros = []
+export-test-macros = [ "camino" ]
 
 [package.metadata.docs.rs]
 features = ["embedded-fs", "async-vfs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 keywords = ["vfs", "virtual", "filesystem", "async"]
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.75"
 
 [badges]
 travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }

--- a/src/async_vfs/filesystem.rs
+++ b/src/async_vfs/filesystem.rs
@@ -2,12 +2,13 @@
 
 use crate::async_vfs::{AsyncVfsPath, SeekAndRead};
 use crate::error::VfsErrorKind;
-use crate::{VfsMetadata, VfsResult};
+use crate::{VfsError, VfsMetadata, VfsResult};
 
 use async_std::io::Write;
 use async_std::stream::Stream;
 use async_trait::async_trait;
 use std::fmt::Debug;
+use std::time::SystemTime;
 
 /// File system implementations must implement this trait
 /// All path parameters are absolute, starting with '/', except for the root directory
@@ -36,6 +37,18 @@ pub trait AsyncFileSystem: Debug + Sync + Send + 'static {
     async fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>>;
     /// Returns the file metadata for the file at this path
     async fn metadata(&self, path: &str) -> VfsResult<VfsMetadata>;
+    /// Sets the files creation timestamp, if the implementation supports it
+    async fn set_creation_time(&self, _path: &str, _time: SystemTime) -> VfsResult<()> {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
+    }
+    /// Sets the files modification timestamp, if the implementation supports it
+    async fn set_modification_time(&self, _path: &str, _time: SystemTime) -> VfsResult<()> {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
+    }
+    /// Sets the files access timestamp, if the implementation supports it
+    async fn set_access_time(&self, _path: &str, _time: SystemTime) -> VfsResult<()> {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
+    }
     /// Returns true if a file or directory at path exists, false otherwise
     async fn exists(&self, path: &str) -> VfsResult<bool>;
     /// Removes the file at this path

--- a/src/async_vfs/impls/altroot.rs
+++ b/src/async_vfs/impls/altroot.rs
@@ -1,8 +1,8 @@
 //! A file system with its root in a particular directory of another filesystem
 
-use std::time::SystemTime;
 use crate::async_vfs::{AsyncFileSystem, AsyncVfsPath, SeekAndRead};
 use crate::{error::VfsErrorKind, VfsMetadata, VfsResult};
+use std::time::SystemTime;
 
 use async_std::io::Write;
 use async_trait::async_trait;
@@ -83,7 +83,6 @@ impl AsyncFileSystem for AsyncAltrootFS {
     async fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
         self.path(path)?.set_access_time(time).await
     }
-
 
     async fn exists(&self, path: &str) -> VfsResult<bool> {
         match self.path(path) {

--- a/src/async_vfs/impls/altroot.rs
+++ b/src/async_vfs/impls/altroot.rs
@@ -1,5 +1,6 @@
 //! A file system with its root in a particular directory of another filesystem
 
+use std::time::SystemTime;
 use crate::async_vfs::{AsyncFileSystem, AsyncVfsPath, SeekAndRead};
 use crate::{error::VfsErrorKind, VfsMetadata, VfsResult};
 
@@ -70,6 +71,19 @@ impl AsyncFileSystem for AsyncAltrootFS {
     async fn metadata(&self, path: &str) -> VfsResult<VfsMetadata> {
         self.path(path)?.metadata().await
     }
+
+    async fn set_creation_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.path(path)?.set_creation_time(time).await
+    }
+
+    async fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.path(path)?.set_modification_time(time).await
+    }
+
+    async fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.path(path)?.set_access_time(time).await
+    }
+
 
     async fn exists(&self, path: &str) -> VfsResult<bool> {
         match self.path(path) {

--- a/src/async_vfs/impls/memory.rs
+++ b/src/async_vfs/impls/memory.rs
@@ -264,6 +264,9 @@ impl AsyncFileSystem for AsyncMemoryFS {
         Ok(VfsMetadata {
             file_type: file.file_type,
             len: file.content.len() as u64,
+            modified: None,
+            created: None,
+            accessed: None,
         })
     }
 

--- a/src/async_vfs/impls/overlay.rs
+++ b/src/async_vfs/impls/overlay.rs
@@ -8,6 +8,7 @@ use async_std::io::Write;
 use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
 use std::collections::HashSet;
+use std::time::SystemTime;
 
 /// An overlay file system combining several filesystems into one, an upper layer with read/write access and lower layers with only read access
 ///
@@ -152,6 +153,18 @@ impl AsyncFileSystem for AsyncOverlayFS {
 
     async fn metadata(&self, path: &str) -> VfsResult<VfsMetadata> {
         self.read_path(path).await?.metadata().await
+    }
+
+    async fn set_creation_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.write_path(path)?.set_creation_time(time).await
+    }
+
+    async fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.write_path(path)?.set_modification_time(time).await
+    }
+
+    async fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.write_path(path)?.set_access_time(time).await
     }
 
     async fn exists(&self, path: &str) -> VfsResult<bool> {

--- a/src/async_vfs/impls/physical.rs
+++ b/src/async_vfs/impls/physical.rs
@@ -89,11 +89,17 @@ impl AsyncFileSystem for AsyncPhysicalFS {
             VfsMetadata {
                 file_type: VfsFileType::Directory,
                 len: 0,
+                modified: metadata.modified().ok(),
+                created: metadata.created().ok(),
+                accessed: metadata.accessed().ok(),
             }
         } else {
             VfsMetadata {
                 file_type: VfsFileType::File,
                 len: metadata.len(),
+                modified: metadata.modified().ok(),
+                created: metadata.created().ok(),
+                accessed: metadata.accessed().ok(),
             }
         })
     }

--- a/src/async_vfs/impls/physical.rs
+++ b/src/async_vfs/impls/physical.rs
@@ -1,4 +1,5 @@
 //! An async implementation of a "physical" file system implementation using the underlying OS file system
+use std::fs::FileTimes;
 use crate::async_vfs::{AsyncFileSystem, SeekAndRead};
 use crate::error::VfsErrorKind;
 use crate::path::VfsFileType;
@@ -10,6 +11,7 @@ use async_std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
 use std::pin::Pin;
+use std::time::SystemTime;
 
 /// A physical filesystem implementation using the underlying OS file system
 #[derive(Debug)]

--- a/src/async_vfs/impls/physical.rs
+++ b/src/async_vfs/impls/physical.rs
@@ -10,6 +10,9 @@ use async_std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
 use std::pin::Pin;
+use std::time::SystemTime;
+use filetime::FileTime;
+use tokio::runtime::Handle;
 
 /// A physical filesystem implementation using the underlying OS file system
 #[derive(Debug)]
@@ -30,6 +33,31 @@ impl AsyncPhysicalFS {
             path = &path[1..];
         }
         self.root.join(path)
+    }
+
+
+}
+
+/// Runs normal blocking io on a tokio thread.
+/// Requires a tokio runtime.
+async fn blocking_io<F>(f: F) -> Result<(), VfsError>
+    where F: FnOnce() -> std::io::Result<()> + Send + 'static
+{
+    if Handle::try_current().is_ok() {
+        let result = tokio::task::spawn_blocking(f).await;
+
+        match result {
+            Ok(val) => { val }
+            Err(err) => {
+                return Err(VfsError::from(
+                    VfsErrorKind::Other(format!("Tokio Concurrency Error: {}", err))
+                ));
+            }
+        }?;
+
+        Ok(())
+    } else {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
     }
 }
 
@@ -102,6 +130,26 @@ impl AsyncFileSystem for AsyncPhysicalFS {
                 accessed: metadata.accessed().ok(),
             }
         })
+    }
+
+    async fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let path = self.get_path(path);
+
+        blocking_io(move || {
+            filetime::set_file_mtime(path, FileTime::from(time))
+        }).await?;
+
+        Ok(())
+    }
+
+    async fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let path = self.get_path(path);
+
+        blocking_io(move || {
+            filetime::set_file_atime(path, FileTime::from(time))
+        }).await?;
+
+        Ok(())
     }
 
     async fn exists(&self, path: &str) -> VfsResult<bool> {

--- a/src/async_vfs/impls/physical.rs
+++ b/src/async_vfs/impls/physical.rs
@@ -1,5 +1,4 @@
 //! An async implementation of a "physical" file system implementation using the underlying OS file system
-use std::fs::FileTimes;
 use crate::async_vfs::{AsyncFileSystem, SeekAndRead};
 use crate::error::VfsErrorKind;
 use crate::path::VfsFileType;
@@ -11,7 +10,6 @@ use async_std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
 use std::pin::Pin;
-use std::time::SystemTime;
 
 /// A physical filesystem implementation using the underlying OS file system
 #[derive(Debug)]

--- a/src/async_vfs/path.rs
+++ b/src/async_vfs/path.rs
@@ -490,7 +490,8 @@ impl AsyncVfsPath {
     pub async fn set_creation_time(&self, time: SystemTime) -> VfsResult<()> {
         self.fs
             .fs
-            .set_creation_time(&self.path, time).await
+            .set_creation_time(&self.path, time)
+            .await
             .map_err(|err| {
                 err.with_path(&*self.path)
                     .with_context(|| "Could not set creation timestamp.")
@@ -519,7 +520,8 @@ impl AsyncVfsPath {
     pub async fn set_modification_time(&self, time: SystemTime) -> VfsResult<()> {
         self.fs
             .fs
-            .set_modification_time(&self.path, time).await
+            .set_modification_time(&self.path, time)
+            .await
             .map_err(|err| {
                 err.with_path(&*self.path)
                     .with_context(|| "Could not set modification timestamp.")
@@ -548,7 +550,8 @@ impl AsyncVfsPath {
     pub async fn set_access_time(&self, time: SystemTime) -> VfsResult<()> {
         self.fs
             .fs
-            .set_access_time(&self.path, time).await
+            .set_access_time(&self.path, time)
+            .await
             .map_err(|err| {
                 err.with_path(&*self.path)
                     .with_context(|| "Could not set access timestamp.")

--- a/src/async_vfs/path.rs
+++ b/src/async_vfs/path.rs
@@ -15,6 +15,7 @@ use async_std::sync::Arc;
 use async_std::task::{Context, Poll};
 use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use std::pin::Pin;
+use std::time::SystemTime;
 
 /// Trait combining Seek and Read, return value for opening files
 pub trait SeekAndRead: Seek + Read {}
@@ -465,6 +466,93 @@ impl AsyncVfsPath {
             err.with_path(&self.path)
                 .with_context(|| "Could not get metadata")
         })
+    }
+
+    /// Sets the files creation timestamp at this path
+    ///
+    /// ```
+    /// use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
+    /// use vfs::{VfsError, VfsFileType, VfsMetadata, VfsPath};
+    /// use async_std::io::WriteExt;
+    /// # tokio_test::block_on(async {
+    /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
+    /// let file = path.join("foo.txt")?;
+    /// file.create_file();
+    ///
+    /// let time = std::time::SystemTime::now();
+    /// file.set_creation_time(time).await?;
+    ///
+    /// assert_eq!(file.metadata().await?.len, 0);
+    /// assert_eq!(file.metadata().await?.created, Some(time));
+    ///
+    /// # Ok::<(), VfsError>(())
+    /// # });
+    pub async fn set_creation_time(&self, time: SystemTime) -> VfsResult<()> {
+        self.fs
+            .fs
+            .set_creation_time(&self.path, time).await
+            .map_err(|err| {
+                err.with_path(&*self.path)
+                    .with_context(|| "Could not set creation timestamp.")
+            })
+    }
+
+    /// Sets the files modification timestamp at this path
+    ///
+    /// ```
+    /// use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
+    /// use vfs::{VfsError, VfsFileType, VfsMetadata, VfsPath};
+    /// use async_std::io::WriteExt;
+    /// # tokio_test::block_on(async {
+    /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
+    /// let file = path.join("foo.txt")?;
+    /// file.create_file();
+    ///
+    /// let time = std::time::SystemTime::now();
+    /// file.set_modification_time(time).await?;
+    ///
+    /// assert_eq!(file.metadata().await?.len, 0);
+    /// assert_eq!(file.metadata().await?.modified, Some(time));
+    ///
+    /// # Ok::<(), VfsError>(())
+    /// # });
+    pub async fn set_modification_time(&self, time: SystemTime) -> VfsResult<()> {
+        self.fs
+            .fs
+            .set_modification_time(&self.path, time).await
+            .map_err(|err| {
+                err.with_path(&*self.path)
+                    .with_context(|| "Could not set modification timestamp.")
+            })
+    }
+
+    /// Sets the files access timestamp at this path
+    ///
+    /// ```
+    /// use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
+    /// use vfs::{VfsError, VfsFileType, VfsMetadata, VfsPath};
+    /// use async_std::io::WriteExt;
+    /// # tokio_test::block_on(async {
+    /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
+    /// let file = path.join("foo.txt")?;
+    /// file.create_file();
+    ///
+    /// let time = std::time::SystemTime::now();
+    /// file.set_access_time(time).await?;
+    ///
+    /// assert_eq!(file.metadata().await?.len, 0);
+    /// assert_eq!(file.metadata().await?.accessed, Some(time));
+    ///
+    /// # Ok::<(), VfsError>(())
+    /// # });
+    pub async fn set_access_time(&self, time: SystemTime) -> VfsResult<()> {
+        self.fs
+            .fs
+            .set_access_time(&self.path, time).await
+            .map_err(|err| {
+                err.with_path(&*self.path)
+                    .with_context(|| "Could not set access timestamp.")
+            })
     }
 
     /// Returns `true` if the path exists and is pointing at a regular file, otherwise returns `false`.

--- a/src/async_vfs/test_macros.rs
+++ b/src/async_vfs/test_macros.rs
@@ -11,6 +11,7 @@ macro_rules! test_async_vfs {
             use $crate::VfsResult;
             use futures::stream::StreamExt;
             use async_std::io::{WriteExt, ReadExt};
+            use std::time::SystemTime;
 
             fn create_root() -> AsyncVfsPath {
                 $root.into()
@@ -19,6 +20,78 @@ macro_rules! test_async_vfs {
             #[tokio::test]
             async fn vfs_can_be_created() {
                 create_root();
+            }
+
+            #[tokio::test]
+            async fn set_and_query_creation_timestamp() -> VfsResult<()> {
+                let root = create_root();
+                let path = root.join("foobar.txt").unwrap();
+                drop( path.create_file().await.unwrap() );
+
+                let time = SystemTime::now();
+                let result = path.set_creation_time(time).await;
+
+                match result {
+                    Err(err) => {
+                        if let VfsErrorKind::NotSupported = err.kind() {
+                            println!("Skipping creation time test: set_creation_time unsupported!");
+                        } else {
+                            return Err(err);
+                        }
+                    },
+                    _ => {
+                        assert_eq!(path.metadata().await?.created, Some(time));
+                    }
+                }
+                Ok(())
+            }
+
+            #[tokio::test]
+            async fn set_and_query_modification_timestamp() -> VfsResult<()> {
+                let root = create_root();
+                let path = root.join("foobar.txt").unwrap();
+                drop( path.create_file().await.unwrap() );
+
+                let time = SystemTime::now();
+                let result = path.set_modification_time(time).await;
+
+                match result {
+                    Err(err) => {
+                        if let VfsErrorKind::NotSupported = err.kind() {
+                            println!("Skipping creation time test: set_modification_time unsupported!");
+                        } else {
+                            return Err(err);
+                        }
+                    },
+                    _ => {
+                        assert_eq!(path.metadata().await?.modified, Some(time));
+                    }
+                }
+                Ok(())
+            }
+
+            #[tokio::test]
+            async fn set_and_query_access_timestamp() -> VfsResult<()> {
+                let root = create_root();
+                let path = root.join("foobar.txt").unwrap();
+                drop( path.create_file().await.unwrap() );
+
+                let time = SystemTime::now();
+                let result = path.set_access_time(time).await;
+
+                match result {
+                    Err(err) => {
+                        if let VfsErrorKind::NotSupported = err.kind() {
+                            println!("Skipping access time test: set_access_time unsupported!");
+                        } else {
+                            return Err(err);
+                        }
+                    },
+                    _ => {
+                        assert_eq!(path.metadata().await?.accessed, Some(time));
+                    }
+                }
+                Ok(())
             }
 
             #[tokio::test]

--- a/src/async_vfs/test_macros.rs
+++ b/src/async_vfs/test_macros.rs
@@ -9,6 +9,7 @@ macro_rules! test_async_vfs {
             use $crate::VfsFileType;
             use $crate::async_vfs::AsyncVfsPath;
             use $crate::VfsResult;
+            use $crate::error::VfsErrorKind;
             use futures::stream::StreamExt;
             use async_std::io::{WriteExt, ReadExt};
             use std::time::SystemTime;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,9 +1,10 @@
 //! The filesystem trait definitions needed to implement new virtual filesystems
 
 use crate::error::VfsErrorKind;
-use crate::{SeekAndRead, VfsMetadata, VfsPath, VfsResult};
+use crate::{SeekAndRead, VfsError, VfsMetadata, VfsPath, VfsResult};
 use std::fmt::Debug;
 use std::io::Write;
+use std::time::SystemTime;
 
 /// File system implementations must implement this trait
 /// All path parameters are absolute, starting with '/', except for the root directory
@@ -28,6 +29,18 @@ pub trait FileSystem: Debug + Sync + Send + 'static {
     fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>>;
     /// Returns the file metadata for the file at this path
     fn metadata(&self, path: &str) -> VfsResult<VfsMetadata>;
+    /// Sets the files creation timestamp, if the implementation supports it
+    fn set_creation_time(&self, _path: &str, _time: SystemTime) -> VfsResult<()> {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
+    }
+    /// Sets the files modification timestamp, if the implementation supports it
+    fn set_modification_time(&self, _path: &str, _time: SystemTime) -> VfsResult<()> {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
+    }
+    /// Sets the files access timestamp, if the implementation supports it
+    fn set_access_time(&self, _path: &str, _time: SystemTime) -> VfsResult<()> {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
+    }
     /// Returns true if a file or directory at path exists, false otherwise
     fn exists(&self, path: &str) -> VfsResult<bool>;
     /// Removes the file at this path

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -2,8 +2,6 @@
 
 use crate::error::VfsErrorKind;
 use crate::{SeekAndRead, SeekAndWrite, VfsError, VfsMetadata, VfsPath, VfsResult};
-use std::fmt::Debug;
-use std::io::Write;
 use std::time::SystemTime;
 use std::fmt::Debug;
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -2,8 +2,8 @@
 
 use crate::error::VfsErrorKind;
 use crate::{SeekAndRead, SeekAndWrite, VfsError, VfsMetadata, VfsPath, VfsResult};
-use std::time::SystemTime;
 use std::fmt::Debug;
+use std::time::SystemTime;
 
 /// File system implementations must implement this trait
 /// All path parameters are absolute, starting with '/', except for the root directory

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -2,6 +2,7 @@
 
 use crate::{error::VfsErrorKind, FileSystem, SeekAndRead, VfsMetadata, VfsPath, VfsResult};
 use std::io::Write;
+use std::time::SystemTime;
 
 /// Similar to a chroot but done purely by path manipulation
 ///
@@ -60,6 +61,18 @@ impl FileSystem for AltrootFS {
 
     fn metadata(&self, path: &str) -> VfsResult<VfsMetadata> {
         self.path(path)?.metadata()
+    }
+
+    fn set_creation_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.path(path)?.set_creation_time(time)
+    }
+
+    fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.path(path)?.set_modification_time(time)
+    }
+
+    fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.path(path)?.set_access_time(time)
     }
 
     fn exists(&self, path: &str) -> VfsResult<bool> {

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -1,7 +1,9 @@
 //! A file system with its root in a particular directory of another filesystem
 
-use crate::{error::VfsErrorKind, FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult};
-use std::io::Write;
+use crate::{
+    error::VfsErrorKind, FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult,
+};
+
 use std::time::SystemTime;
 
 /// Similar to a chroot but done purely by path manipulation

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -1,6 +1,6 @@
 //! A file system with its root in a particular directory of another filesystem
 
-use crate::{error::VfsErrorKind, FileSystem, SeekAndRead, VfsMetadata, VfsMetadata, VfsPath, VfsResult};
+use crate::{error::VfsErrorKind, FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult};
 use std::io::Write;
 use std::time::SystemTime;
 

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -123,9 +123,13 @@ where
                 Some(file) => Ok(VfsMetadata {
                     file_type: VfsFileType::File,
                     len: *len,
-                    modified: file.metadata.last_modified()
+                    modified: file
+                        .metadata
+                        .last_modified()
                         .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs)),
-                    created: file.metadata.created()
+                    created: file
+                        .metadata
+                        .created()
                         .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs)),
                     accessed: None,
                 }),

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::io::{Cursor, Write};
 use std::marker::PhantomData;
+use std::time::{Duration, SystemTime};
 
 use rust_embed::RustEmbed;
 
@@ -117,13 +118,18 @@ where
     fn metadata(&self, path: &str) -> VfsResult<VfsMetadata> {
         let normalized_path = normalize_path(path)?;
         if let Some(len) = self.files.get(normalized_path) {
-            return Ok(VfsMetadata {
-                file_type: VfsFileType::File,
-                len: *len,
-                modified: None,
-                created: None,
-                accessed: None,
-            });
+            return match T::get(path.split_at(1).1) {
+                None => Err(VfsErrorKind::FileNotFound.into()),
+                Some(file) => Ok(VfsMetadata {
+                    file_type: VfsFileType::File,
+                    len: *len,
+                    modified: file.metadata.last_modified()
+                        .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs)),
+                    created: file.metadata.created()
+                        .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs)),
+                    accessed: None,
+                }),
+            };
         }
         if self.directory_map.contains_key(normalized_path) {
             return Ok(VfsMetadata {

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -120,12 +120,18 @@ where
             return Ok(VfsMetadata {
                 file_type: VfsFileType::File,
                 len: *len,
+                modified: None,
+                created: None,
+                accessed: None,
             });
         }
         if self.directory_map.contains_key(normalized_path) {
             return Ok(VfsMetadata {
                 file_type: VfsFileType::Directory,
                 len: 0,
+                modified: None,
+                created: None,
+                accessed: None,
             });
         }
         Err(VfsErrorKind::FileNotFound.into())

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -222,7 +222,7 @@ impl FileSystem for MemoryFS {
             len: file.content.len() as u64,
             modified: None,
             created: None,
-            accessed: None
+            accessed: None,
         })
     }
 

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -12,6 +12,7 @@ use std::fmt::{Debug, Formatter};
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::mem::swap;
 use std::sync::{Arc, RwLock};
+use std::time::SystemTime;
 
 type MemoryFsHandle = Arc<RwLock<MemoryFsImpl>>;
 
@@ -71,12 +72,22 @@ impl Drop for WritableFile {
     fn drop(&mut self) {
         let mut content = vec![];
         swap(&mut content, self.content.get_mut());
-        self.fs.write().unwrap().files.insert(
+        let mut handle = self.fs.write().unwrap();
+        let previous_file = handle.files.get(
+            &self.destination
+        );
+
+        let new_file = MemoryFile {
+            file_type: VfsFileType::File,
+            content: Arc::new(content),
+            created: previous_file.map(|file| file.created).unwrap_or(SystemTime::now()),
+            modified: Some(SystemTime::now()),
+            accessed: previous_file.map(|file| file.accessed).unwrap_or(None)
+        };
+
+        handle.files.insert(
             self.destination.clone(),
-            MemoryFile {
-                file_type: VfsFileType::File,
-                content: Arc::new(content),
-            },
+            new_file,
         );
     }
 }
@@ -165,6 +176,9 @@ impl FileSystem for MemoryFS {
                     MemoryFile {
                         file_type: VfsFileType::Directory,
                         content: Default::default(),
+                        created: SystemTime::now(),
+                        modified: None,
+                        accessed: None,
                     },
                 );
             }
@@ -173,6 +187,8 @@ impl FileSystem for MemoryFS {
     }
 
     fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>> {
+        self.set_access_time(path, SystemTime::now())?;
+
         let handle = self.handle.read().unwrap();
         let file = handle.files.get(path).ok_or(VfsErrorKind::FileNotFound)?;
         ensure_file(file)?;
@@ -190,6 +206,9 @@ impl FileSystem for MemoryFS {
             MemoryFile {
                 file_type: VfsFileType::File,
                 content,
+                created: SystemTime::now(),
+                modified: Some(SystemTime::now()),
+                accessed: Some(SystemTime::now())
             },
         );
         let writer = WritableFile {
@@ -220,10 +239,40 @@ impl FileSystem for MemoryFS {
         Ok(VfsMetadata {
             file_type: file.file_type,
             len: file.content.len() as u64,
-            modified: None,
-            created: None,
-            accessed: None,
+            modified: file.modified,
+            created: Some(file.created),
+            accessed: file.accessed,
         })
+    }
+
+    fn set_creation_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let mut guard = self.handle.write().unwrap();
+        let files = &mut guard.files;
+        let file = files.get_mut(path).ok_or(VfsErrorKind::FileNotFound)?;
+
+        file.created = time;
+
+        Ok(())
+    }
+
+    fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let mut guard = self.handle.write().unwrap();
+        let files = &mut guard.files;
+        let file = files.get_mut(path).ok_or(VfsErrorKind::FileNotFound)?;
+
+        file.modified = Some(time);
+
+        Ok(())
+    }
+
+    fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let mut guard = self.handle.write().unwrap();
+        let files = &mut guard.files;
+        let file = files.get_mut(path).ok_or(VfsErrorKind::FileNotFound)?;
+
+        file.accessed = Some(time);
+
+        Ok(())
     }
 
     fn exists(&self, path: &str) -> VfsResult<bool> {
@@ -265,6 +314,9 @@ impl MemoryFsImpl {
             MemoryFile {
                 file_type: VfsFileType::Directory,
                 content: Arc::new(vec![]),
+                created: SystemTime::now(),
+                modified: None,
+                accessed: None,
             },
         );
         Self { files }
@@ -275,6 +327,10 @@ struct MemoryFile {
     file_type: VfsFileType,
     #[allow(clippy::rc_buffer)] // to allow accessing the same object as writable
     content: Arc<Vec<u8>>,
+
+    created: SystemTime,
+    modified: Option<SystemTime>,
+    accessed: Option<SystemTime>,
 }
 
 #[cfg(test)]

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -336,6 +336,13 @@ struct MemoryFile {
     accessed: Option<SystemTime>,
 }
 
+fn ensure_file(file: &MemoryFile) -> VfsResult<()> {
+    if file.file_type != VfsFileType::File {
+        return Err(VfsErrorKind::Other("Not a file".into()).into());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -476,11 +483,4 @@ mod tests {
         assert_eq!(&dest.read_to_string()?, "Hello World");
         Ok(())
     }
-}
-
-fn ensure_file(file: &MemoryFile) -> VfsResult<()> {
-    if file.file_type != VfsFileType::File {
-        return Err(VfsErrorKind::Other("Not a file".into()).into());
-    }
-    Ok(())
 }

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -174,8 +174,8 @@ impl FileSystem for MemoryFS {
                         file_type: VfsFileType::Directory,
                         content: Default::default(),
                         created: SystemTime::now(),
-                        modified: None,
-                        accessed: None,
+                        modified: Some(SystemTime::now()),
+                        accessed: Some(SystemTime::now()),
                     },
                 );
             }

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -73,22 +73,19 @@ impl Drop for WritableFile {
         let mut content = vec![];
         swap(&mut content, self.content.get_mut());
         let mut handle = self.fs.write().unwrap();
-        let previous_file = handle.files.get(
-            &self.destination
-        );
+        let previous_file = handle.files.get(&self.destination);
 
         let new_file = MemoryFile {
             file_type: VfsFileType::File,
             content: Arc::new(content),
-            created: previous_file.map(|file| file.created).unwrap_or(SystemTime::now()),
+            created: previous_file
+                .map(|file| file.created)
+                .unwrap_or(SystemTime::now()),
             modified: Some(SystemTime::now()),
-            accessed: previous_file.map(|file| file.accessed).unwrap_or(None)
+            accessed: previous_file.map(|file| file.accessed).unwrap_or(None),
         };
 
-        handle.files.insert(
-            self.destination.clone(),
-            new_file,
-        );
+        handle.files.insert(self.destination.clone(), new_file);
     }
 }
 
@@ -208,7 +205,7 @@ impl FileSystem for MemoryFS {
                 content,
                 created: SystemTime::now(),
                 modified: Some(SystemTime::now()),
-                accessed: Some(SystemTime::now())
+                accessed: Some(SystemTime::now()),
             },
         );
         let writer = WritableFile {

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -220,6 +220,9 @@ impl FileSystem for MemoryFS {
         Ok(VfsMetadata {
             file_type: file.file_type,
             len: file.content.len() as u64,
+            modified: None,
+            created: None,
+            accessed: None
         })
     }
 

--- a/src/impls/overlay.rs
+++ b/src/impls/overlay.rs
@@ -4,6 +4,7 @@ use crate::error::VfsErrorKind;
 use crate::{FileSystem, SeekAndRead, VfsMetadata, VfsPath, VfsResult};
 use std::collections::HashSet;
 use std::io::Write;
+use std::time::SystemTime;
 
 /// An overlay file system combining several filesystems into one, an upper layer with read/write access and lower layers with only read access
 ///
@@ -142,6 +143,18 @@ impl FileSystem for OverlayFS {
 
     fn metadata(&self, path: &str) -> VfsResult<VfsMetadata> {
         self.read_path(path)?.metadata()
+    }
+
+    fn set_creation_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.write_path(path)?.set_creation_time(time)
+    }
+
+    fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.write_path(path)?.set_modification_time(time)
+    }
+
+    fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        self.write_path(path)?.set_access_time(time)
     }
 
     fn exists(&self, path: &str) -> VfsResult<bool> {

--- a/src/impls/overlay.rs
+++ b/src/impls/overlay.rs
@@ -3,9 +3,8 @@
 use crate::error::VfsErrorKind;
 use crate::{FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult};
 use std::collections::HashSet;
-use std::io::Write;
-use std::time::SystemTime;
 
+use std::time::SystemTime;
 
 /// An overlay file system combining several filesystems into one, an upper layer with read/write access and lower layers with only read access
 ///

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -8,6 +8,7 @@ use std::fs::{File, FileTimes, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+use filetime::FileTime;
 
 /// A physical filesystem implementation using the underlying OS file system
 #[derive(Debug)]
@@ -92,18 +93,12 @@ impl FileSystem for PhysicalFS {
     }
 
     fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
-        let dest = File::options().write(true).open(self.get_path(path))?;
-        let times = FileTimes::new().set_modified(time);
-        dest.set_times(times)?;
-
+        filetime::set_file_mtime(self.get_path(path), FileTime::from(time))?;
         Ok(())
     }
 
     fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
-        let dest = File::options().write(true).open(self.get_path(path))?;
-        let times = FileTimes::new().set_accessed(time);
-        dest.set_times(times)?;
-
+        filetime::set_file_atime(self.get_path(path), FileTime::from(time))?;
         Ok(())
     }
 

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -92,22 +92,16 @@ impl FileSystem for PhysicalFS {
     }
 
     fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
-        let dest = File::options().write(true).open(
-            self.get_path(path)
-        )?;
-        let times = FileTimes::new()
-            .set_modified(time);
+        let dest = File::options().write(true).open(self.get_path(path))?;
+        let times = FileTimes::new().set_modified(time);
         dest.set_times(times)?;
 
         Ok(())
     }
 
     fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
-        let dest = File::options().write(true).open(
-            self.get_path(path)
-        )?;
-        let times = FileTimes::new()
-            .set_accessed(time);
+        let dest = File::options().write(true).open(self.get_path(path))?;
+        let times = FileTimes::new().set_accessed(time);
         dest.set_times(times)?;
 
         Ok(())

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -75,11 +75,17 @@ impl FileSystem for PhysicalFS {
             VfsMetadata {
                 file_type: VfsFileType::Directory,
                 len: 0,
+                modified: metadata.modified().ok(),
+                created: metadata.created().ok(),
+                accessed: metadata.accessed().ok(),
             }
         } else {
             VfsMetadata {
                 file_type: VfsFileType::File,
                 len: metadata.len(),
+                modified: metadata.modified().ok(),
+                created: metadata.created().ok(),
+                accessed: metadata.accessed().ok(),
             }
         })
     }

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -4,11 +4,11 @@ use crate::error::VfsErrorKind;
 use crate::{FileSystem, SeekAndWrite, VfsMetadata};
 use crate::{SeekAndRead, VfsFileType};
 use crate::{VfsError, VfsResult};
+use filetime::FileTime;
 use std::fs::{File, OpenOptions};
-use std::io::{ErrorKind, Write};
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
-use filetime::FileTime;
 
 /// A physical filesystem implementation using the underlying OS file system
 #[derive(Debug)]

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -4,9 +4,10 @@ use crate::error::VfsErrorKind;
 use crate::{FileSystem, VfsMetadata};
 use crate::{SeekAndRead, VfsFileType};
 use crate::{VfsError, VfsResult};
-use std::fs::{File, OpenOptions};
+use std::fs::{File, FileTimes, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 /// A physical filesystem implementation using the underlying OS file system
 #[derive(Debug)]
@@ -88,6 +89,28 @@ impl FileSystem for PhysicalFS {
                 accessed: metadata.accessed().ok(),
             }
         })
+    }
+
+    fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let dest = File::options().write(true).open(
+            self.get_path(path)
+        )?;
+        let times = FileTimes::new()
+            .set_modified(time);
+        dest.set_times(times)?;
+
+        Ok(())
+    }
+
+    fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let dest = File::options().write(true).open(
+            self.get_path(path)
+        )?;
+        let times = FileTimes::new()
+            .set_accessed(time);
+        dest.set_times(times)?;
+
+        Ok(())
     }
 
     fn exists(&self, path: &str) -> VfsResult<bool> {

--- a/src/path.rs
+++ b/src/path.rs
@@ -94,6 +94,12 @@ pub struct VfsMetadata {
     pub file_type: VfsFileType,
     /// Length of the file in bytes, 0 for directories
     pub len: u64,
+    /// Modification time of the file, if supported by the vfs implementation
+    pub modified: Option<std::time::SystemTime>,
+    /// Creation time of the file, if supported by the vfs implementation
+    pub created:  Option<std::time::SystemTime>,
+    /// Access time of the file, if supported by the vfs implementation
+    pub accessed: Option<std::time::SystemTime>,
 }
 
 #[derive(Debug)]

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,6 +5,7 @@
 
 use std::io::{Read, Seek, Write};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use crate::error::VfsErrorKind;
 use crate::{FileSystem, VfsError, VfsResult};
@@ -94,12 +95,12 @@ pub struct VfsMetadata {
     pub file_type: VfsFileType,
     /// Length of the file in bytes, 0 for directories
     pub len: u64,
-    /// Modification time of the file, if supported by the vfs implementation
-    pub modified: Option<std::time::SystemTime>,
     /// Creation time of the file, if supported by the vfs implementation
-    pub created: Option<std::time::SystemTime>,
+    pub created: Option<SystemTime>,
+    /// Modification time of the file, if supported by the vfs implementation
+    pub modified: Option<SystemTime>,
     /// Access time of the file, if supported by the vfs implementation
-    pub accessed: Option<std::time::SystemTime>,
+    pub accessed: Option<SystemTime>,
 }
 
 #[derive(Debug)]
@@ -505,6 +506,78 @@ impl VfsPath {
         self.fs.fs.metadata(&self.path).map_err(|err| {
             err.with_path(&*self.path)
                 .with_context(|| "Could not get metadata")
+        })
+    }
+
+    /// Returns the file metadata for the file at this path
+    ///
+    /// ```
+    /// # use std::io::Read;
+    /// use std::time::SystemTime;
+    /// use vfs::{MemoryFS, VfsError, VfsFileType, VfsMetadata, VfsPath};
+    /// let path = VfsPath::new(MemoryFS::new());
+    /// let file = path.join("foo.txt")?;
+    /// file.create_file();
+    ///
+    /// let time = SystemTime::now();
+    /// file.set_creation_time(time);
+    ///
+    /// assert_eq!(file.metadata()?.len, 0);
+    /// assert_eq!(file.metadata()?.created, Some(time));
+    ///
+    /// # Ok::<(), VfsError>(())
+    pub fn set_creation_time(&self, time: SystemTime) -> VfsResult<()> {
+        self.fs.fs.set_creation_time(&self.path, time).map_err(|err| {
+            err.with_path(&*self.path)
+                .with_context(|| "Could not set creation timestamp.")
+        })
+    }
+
+    /// Returns the file metadata for the file at this path
+    ///
+    /// ```
+    /// # use std::io::Read;
+    /// use std::time::SystemTime;
+    /// use vfs::{MemoryFS, VfsError, VfsFileType, VfsMetadata, VfsPath};
+    /// let path = VfsPath::new(MemoryFS::new());
+    /// let file = path.join("foo.txt")?;
+    /// file.create_file();
+    ///
+    /// let time = SystemTime::now();
+    /// file.set_modification_time(time);
+    ///
+    /// assert_eq!(file.metadata()?.len, 0);
+    /// assert_eq!(file.metadata()?.modified, Some(time));
+    ///
+    /// # Ok::<(), VfsError>(())
+    pub fn set_modification_time(&self, time: SystemTime) -> VfsResult<()> {
+        self.fs.fs.set_modification_time(&self.path, time).map_err(|err| {
+            err.with_path(&*self.path)
+                .with_context(|| "Could not set modification timestamp.")
+        })
+    }
+
+    /// Returns the file metadata for the file at this path
+    ///
+    /// ```
+    /// # use std::io::Read;
+    /// use std::time::SystemTime;
+    /// use vfs::{MemoryFS, VfsError, VfsFileType, VfsMetadata, VfsPath};
+    /// let path = VfsPath::new(MemoryFS::new());
+    /// let file = path.join("foo.txt")?;
+    /// file.create_file();
+    ///
+    /// let time = SystemTime::now();
+    /// file.set_access_time(time);
+    ///
+    /// assert_eq!(file.metadata()?.len, 0);
+    /// assert_eq!(file.metadata()?.accessed, Some(time));
+    ///
+    /// # Ok::<(), VfsError>(())
+    pub fn set_access_time(&self, time: SystemTime) -> VfsResult<()> {
+        self.fs.fs.set_access_time(&self.path, time).map_err(|err| {
+            err.with_path(&*self.path)
+                .with_context(|| "Could not set access timestamp.")
         })
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -527,10 +527,13 @@ impl VfsPath {
     ///
     /// # Ok::<(), VfsError>(())
     pub fn set_creation_time(&self, time: SystemTime) -> VfsResult<()> {
-        self.fs.fs.set_creation_time(&self.path, time).map_err(|err| {
-            err.with_path(&*self.path)
-                .with_context(|| "Could not set creation timestamp.")
-        })
+        self.fs
+            .fs
+            .set_creation_time(&self.path, time)
+            .map_err(|err| {
+                err.with_path(&*self.path)
+                    .with_context(|| "Could not set creation timestamp.")
+            })
     }
 
     /// Returns the file metadata for the file at this path
@@ -551,10 +554,13 @@ impl VfsPath {
     ///
     /// # Ok::<(), VfsError>(())
     pub fn set_modification_time(&self, time: SystemTime) -> VfsResult<()> {
-        self.fs.fs.set_modification_time(&self.path, time).map_err(|err| {
-            err.with_path(&*self.path)
-                .with_context(|| "Could not set modification timestamp.")
-        })
+        self.fs
+            .fs
+            .set_modification_time(&self.path, time)
+            .map_err(|err| {
+                err.with_path(&*self.path)
+                    .with_context(|| "Could not set modification timestamp.")
+            })
     }
 
     /// Returns the file metadata for the file at this path

--- a/src/path.rs
+++ b/src/path.rs
@@ -97,7 +97,7 @@ pub struct VfsMetadata {
     /// Modification time of the file, if supported by the vfs implementation
     pub modified: Option<std::time::SystemTime>,
     /// Creation time of the file, if supported by the vfs implementation
-    pub created:  Option<std::time::SystemTime>,
+    pub created: Option<std::time::SystemTime>,
     /// Access time of the file, if supported by the vfs implementation
     pub accessed: Option<std::time::SystemTime>,
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -509,7 +509,7 @@ impl VfsPath {
         })
     }
 
-    /// Returns the file metadata for the file at this path
+    /// Sets the files creation timestamp at this path
     ///
     /// ```
     /// # use std::io::Read;
@@ -536,7 +536,7 @@ impl VfsPath {
             })
     }
 
-    /// Returns the file metadata for the file at this path
+    /// Sets the files modification timestamp at this path
     ///
     /// ```
     /// # use std::io::Read;
@@ -563,7 +563,7 @@ impl VfsPath {
             })
     }
 
-    /// Returns the file metadata for the file at this path
+    /// Sets the files access timestamp at this path
     ///
     /// ```
     /// # use std::io::Read;

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -9,6 +9,7 @@ macro_rules! test_vfs {
             use $crate::VfsFileType;
             use $crate::VfsPath;
             use $crate::VfsResult;
+            use std::time::SystemTime;
 
             fn create_root() -> VfsPath {
                 $root.into()
@@ -17,6 +18,78 @@ macro_rules! test_vfs {
             #[test]
             fn vfs_can_be_created() {
                 create_root();
+            }
+
+            #[test]
+            fn set_and_query_creation_timestamp() -> VfsResult<()> {
+                let root = create_root();
+                let path = root.join("foobar.txt").unwrap();
+                drop( path.create_file().unwrap() );
+
+                let time = SystemTime::now();
+                let result = path.set_creation_time(time);
+
+                match result {
+                    Err(err) => {
+                        if let VfsErrorKind::NotSupported = err.kind() {
+                            println!("Skipping creation time test: set_creation_time unsupported!");
+                        } else {
+                            return Err(err);
+                        }
+                    },
+                    _ => {
+                        assert_eq!(path.metadata()?.created, Some(time));
+                    }
+                }
+                Ok(())
+            }
+
+             #[test]
+            fn set_and_query_modification_timestamp() -> VfsResult<()> {
+                let root = create_root();
+                let path = root.join("foobar.txt").unwrap();
+                drop( path.create_file().unwrap() );
+
+                let time = SystemTime::now();
+                let result = path.set_modification_time(time);
+
+                match result {
+                    Err(err) => {
+                        if let VfsErrorKind::NotSupported = err.kind() {
+                            println!("Skipping creation time test: set_modification_time unsupported!");
+                        } else {
+                            return Err(err);
+                        }
+                    },
+                    _ => {
+                        assert_eq!(path.metadata()?.modified, Some(time));
+                    }
+                }
+                Ok(())
+            }
+
+             #[test]
+            fn set_and_query_access_timestamp() -> VfsResult<()> {
+                let root = create_root();
+                let path = root.join("foobar.txt").unwrap();
+                drop( path.create_file().unwrap() );
+
+                let time = SystemTime::now();
+                let result = path.set_access_time(time);
+
+                match result {
+                    Err(err) => {
+                        if let VfsErrorKind::NotSupported = err.kind() {
+                            println!("Skipping access time test: set_access_time unsupported!");
+                        } else {
+                            return Err(err);
+                        }
+                    },
+                    _ => {
+                        assert_eq!(path.metadata()?.accessed, Some(time));
+                    }
+                }
+                Ok(())
             }
 
             #[test]

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -159,7 +159,6 @@ macro_rules! test_vfs {
                 assert_eq!(metadata.len, 0);
             }
 
-            /*
             #[test]
             fn create_dir_with_camino() {
                 let root = create_root();
@@ -169,7 +168,7 @@ macro_rules! test_vfs {
                 let metadata = path.metadata().unwrap();
                 assert_eq!(metadata.file_type, VfsFileType::Directory);
                 assert_eq!(metadata.len, 0);
-            }*/
+            }
 
             #[test]
             fn create_dir_all() -> VfsResult<()>{

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -9,6 +9,7 @@ macro_rules! test_vfs {
             use $crate::VfsFileType;
             use $crate::VfsPath;
             use $crate::VfsResult;
+            use $crate::VfsErrorKind;
             use std::time::SystemTime;
 
             fn create_root() -> VfsPath {
@@ -158,6 +159,7 @@ macro_rules! test_vfs {
                 assert_eq!(metadata.len, 0);
             }
 
+            /*
             #[test]
             fn create_dir_with_camino() {
                 let root = create_root();
@@ -167,7 +169,7 @@ macro_rules! test_vfs {
                 let metadata = path.metadata().unwrap();
                 assert_eq!(metadata.file_type, VfsFileType::Directory);
                 assert_eq!(metadata.len, 0);
-            }
+            }*/
 
             #[test]
             fn create_dir_all() -> VfsResult<()>{

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -9,7 +9,7 @@ macro_rules! test_vfs {
             use $crate::VfsFileType;
             use $crate::VfsPath;
             use $crate::VfsResult;
-            use $crate::VfsErrorKind;
+            use $crate::error::VfsErrorKind;
             use std::time::SystemTime;
 
             fn create_root() -> VfsPath {


### PR DESCRIPTION
This small change adds the file modification birth and access times to the VfsMetadata struct.

These times are encapsulated in `Option<>`, as they are not guaranteed to be available even in `std::fs::metadata`.

I have implemented the metadata timestamps for PhysicalFS, though it may be possible to support them for the in memory database as well.

### Motivation
I am planning on writing a minimal vfs implementation for MTS (Media Transfer Protocol).
I don't know yet if this is going to work, especially since there are few crates for MTS - but maybe i can make it work.

In the final product i will need access to the mtime field.