### PR TITLE
Allow seek when writing

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,7 +1,7 @@
 //! The filesystem trait definitions needed to implement new virtual filesystems
 
 use crate::error::VfsErrorKind;
-use crate::{SeekAndRead, VfsMetadata, VfsPath, VfsResult};
+use crate::{SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult};
 use std::fmt::Debug;
 use std::io::Write;
 
@@ -23,9 +23,9 @@ pub trait FileSystem: Debug + Sync + Send + 'static {
     /// Opens the file at this path for reading
     fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send>>;
     /// Creates a file at this path for writing
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>>;
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>>;
     /// Opens the file at this path for appending
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>>;
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>>;
     /// Returns the file metadata for the file at this path
     fn metadata(&self, path: &str) -> VfsResult<VfsMetadata>;
     /// Returns true if a file or directory at path exists, false otherwise

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -3,7 +3,6 @@
 use crate::error::VfsErrorKind;
 use crate::{SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult};
 use std::fmt::Debug;
-use std::io::Write;
 
 /// File system implementations must implement this trait
 /// All path parameters are absolute, starting with '/', except for the root directory

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -1,6 +1,8 @@
 //! A file system with its root in a particular directory of another filesystem
 
-use crate::{error::VfsErrorKind, FileSystem, SeekAndRead, VfsMetadata, VfsPath, VfsResult};
+use crate::{
+    error::VfsErrorKind, FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult,
+};
 use std::io::Write;
 
 /// Similar to a chroot but done purely by path manipulation
@@ -50,11 +52,11 @@ impl FileSystem for AltrootFS {
         self.path(path)?.open_file()
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         self.path(path)?.create_file()
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         self.path(path)?.append_file()
     }
 

--- a/src/impls/altroot.rs
+++ b/src/impls/altroot.rs
@@ -3,7 +3,6 @@
 use crate::{
     error::VfsErrorKind, FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult,
 };
-use std::io::Write;
 
 /// Similar to a chroot but done purely by path manipulation
 ///

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use rust_embed::RustEmbed;
 
 use crate::error::VfsErrorKind;
-use crate::{FileSystem, SeekAndRead, VfsFileType, VfsMetadata, VfsResult};
+use crate::{FileSystem, SeekAndRead, SeekAndWrite, VfsFileType, VfsMetadata, VfsResult};
 
 type EmbeddedPath = Cow<'static, str>;
 
@@ -106,11 +106,11 @@ where
         }
     }
 
-    fn create_file(&self, _path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn create_file(&self, _path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         Err(VfsErrorKind::NotSupported.into())
     }
 
-    fn append_file(&self, _path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn append_file(&self, _path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         Err(VfsErrorKind::NotSupported.into())
     }
 

--- a/src/impls/embedded.rs
+++ b/src/impls/embedded.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
-use std::io::{Cursor, Write};
+use std::io::Cursor;
 use std::marker::PhantomData;
 
 use rust_embed::RustEmbed;

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -1,9 +1,9 @@
 //! An ephemeral in-memory file system, intended mainly for unit tests
 
 use crate::error::VfsErrorKind;
-use crate::VfsResult;
 use crate::{FileSystem, VfsFileType};
 use crate::{SeekAndRead, VfsMetadata};
+use crate::{SeekAndWrite, VfsResult};
 use core::cmp;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -55,6 +55,12 @@ struct WritableFile {
     content: Cursor<Vec<u8>>,
     destination: String,
     fs: MemoryFsHandle,
+}
+
+impl Seek for WritableFile {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.content.seek(pos)
+    }
 }
 
 impl Write for WritableFile {
@@ -182,7 +188,7 @@ impl FileSystem for MemoryFS {
         }))
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         self.ensure_has_parent(path)?;
         let content = Arc::new(Vec::<u8>::new());
         self.handle.write().unwrap().files.insert(
@@ -200,7 +206,7 @@ impl FileSystem for MemoryFS {
         Ok(Box::new(writer))
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         let handle = self.handle.write().unwrap();
         let file = handle.files.get(path).ok_or(VfsErrorKind::FileNotFound)?;
         let mut content = Cursor::new(file.content.as_ref().clone());

--- a/src/impls/overlay.rs
+++ b/src/impls/overlay.rs
@@ -3,7 +3,6 @@
 use crate::error::VfsErrorKind;
 use crate::{FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult};
 use std::collections::HashSet;
-use std::io::Write;
 
 /// An overlay file system combining several filesystems into one, an upper layer with read/write access and lower layers with only read access
 ///

--- a/src/impls/overlay.rs
+++ b/src/impls/overlay.rs
@@ -1,7 +1,7 @@
 //! An overlay file system combining two filesystems, an upper layer with read/write access and a lower layer with only read access
 
 use crate::error::VfsErrorKind;
-use crate::{FileSystem, SeekAndRead, VfsMetadata, VfsPath, VfsResult};
+use crate::{FileSystem, SeekAndRead, SeekAndWrite, VfsMetadata, VfsPath, VfsResult};
 use std::collections::HashSet;
 use std::io::Write;
 
@@ -121,7 +121,7 @@ impl FileSystem for OverlayFS {
         self.read_path(path)?.open_file()
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         self.ensure_has_parent(path)?;
         let result = self.write_path(path)?.create_file()?;
         let whiteout_path = self.whiteout_path(path)?;
@@ -131,7 +131,7 @@ impl FileSystem for OverlayFS {
         Ok(result)
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         let write_path = self.write_path(path)?;
         if !write_path.exists()? {
             self.ensure_has_parent(path)?;

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -1,7 +1,7 @@
 //! A "physical" file system implementation using the underlying OS file system
 
 use crate::error::VfsErrorKind;
-use crate::{FileSystem, VfsMetadata};
+use crate::{FileSystem, SeekAndWrite, VfsMetadata};
 use crate::{SeekAndRead, VfsFileType};
 use crate::{VfsError, VfsResult};
 use std::fs::{File, OpenOptions};
@@ -59,11 +59,11 @@ impl FileSystem for PhysicalFS {
         Ok(Box::new(File::open(self.get_path(path))?))
     }
 
-    fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn create_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         Ok(Box::new(File::create(self.get_path(path))?))
     }
 
-    fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send>> {
+    fn append_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         Ok(Box::new(
             OpenOptions::new().append(true).open(self.get_path(path))?,
         ))

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -5,7 +5,7 @@ use crate::{FileSystem, SeekAndWrite, VfsMetadata};
 use crate::{SeekAndRead, VfsFileType};
 use crate::{VfsError, VfsResult};
 use std::fs::{File, OpenOptions};
-use std::io::{ErrorKind, Write};
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 /// A physical filesystem implementation using the underlying OS file system

--- a/src/path.rs
+++ b/src/path.rs
@@ -12,7 +12,12 @@ use crate::{FileSystem, VfsError, VfsResult};
 /// Trait combining Seek and Read, return value for opening files
 pub trait SeekAndRead: Seek + Read {}
 
+/// Trait combining Seek and Write, return value for writing files
+pub trait SeekAndWrite: Seek + Write {}
+
 impl<T> SeekAndRead for T where T: Seek + Read {}
+
+impl<T> SeekAndWrite for T where T: Seek + Write {}
 
 /// A trait for common non-async behaviour of both sync and async paths
 pub(crate) trait PathLike: Clone {
@@ -327,7 +332,7 @@ impl VfsPath {
     /// assert_eq!(&result, "Hello, world!");
     /// # Ok::<(), VfsError>(())
     /// ```
-    pub fn create_file(&self) -> VfsResult<Box<dyn Write + Send>> {
+    pub fn create_file(&self) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         self.get_parent("create file")?;
         self.fs.fs.create_file(&self.path).map_err(|err| {
             err.with_path(&*self.path)
@@ -392,7 +397,7 @@ impl VfsPath {
     /// assert_eq!(&result, "Hello, world!");
     /// # Ok::<(), VfsError>(())
     /// ```
-    pub fn append_file(&self) -> VfsResult<Box<dyn Write + Send>> {
+    pub fn append_file(&self) -> VfsResult<Box<dyn SeekAndWrite + Send>> {
         self.fs.fs.append_file(&self.path).map_err(|err| {
             err.with_path(&*self.path)
                 .with_context(|| "Could not open file for appending")

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -5,7 +5,8 @@ macro_rules! test_vfs {
     ($root:expr) => {
         #[cfg(test)]
         mod vfs_tests {
-            use super::*;
+            use std::io::{Seek, SeekFrom};
+use super::*;
             use $crate::VfsFileType;
             use $crate::VfsPath;
             use $crate::VfsResult;
@@ -39,6 +40,32 @@ macro_rules! test_vfs {
                 assert!(!root.join("foo").unwrap().exists()?);
                 let metadata = path.metadata().unwrap();
                 assert_eq!(metadata.len, 12);
+                assert_eq!(metadata.file_type, VfsFileType::File);
+                Ok(())
+            }
+
+            #[test]
+            fn write_and_seek_and_read_file()  -> VfsResult<()>{
+                let root = create_root();
+                let path = root.join("foobar.txt").unwrap();
+                let _send = &path as &dyn Send;
+                {
+                    let mut file = path.create_file().unwrap();
+                    write!(file, "Hello world").unwrap();
+                    write!(file, "!").unwrap();
+                    file.seek(SeekFrom::Start(5)).unwrap();
+                    write!(file, "SeekCompleted").unwrap();
+                }
+                {
+                    let mut file = path.open_file().unwrap();
+                    let mut string: String = String::new();
+                    file.read_to_string(&mut string).unwrap();
+                    assert_eq!(string, "HelloSeekCompleted");
+                }
+                assert!(path.exists()?);
+                assert!(!root.join("foo").unwrap().exists()?);
+                let metadata = path.metadata().unwrap();
+                assert_eq!(metadata.len, 18);
                 assert_eq!(metadata.file_type, VfsFileType::File);
                 Ok(())
             }


### PR DESCRIPTION
The standard Rust File struct allows seeking when writing to files so VFS should as well.  VFS already allows seek when reading files.

This is useful when testing code that reads & writes sections of a file.