### PR TITLE
Fix capitalisation in doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!  * **[`MemoryFS`](impls/memory/struct.MemoryFS.html)** - an ephemeral in-memory implementation (intended for unit tests)
 //!  * **[`AltrootFS`](impls/altroot/struct.AltrootFS.html)** - a file system with its root in a particular directory of another filesystem
 //!  * **[`OverlayFS`](impls/overlay/struct.OverlayFS.html)** - a union file system consisting of a read/writable upper layer and several read-only lower layers
-//!  * **[`EmbeddedFS`](impls/embedded/struct.EmbeddedFs.html)** - a read-only file system embedded in the executable, requires `embedded-fs` feature
+//!  * **[`EmbeddedFS`](impls/embedded/struct.EmbeddedFS.html)** - a read-only file system embedded in the executable, requires `embedded-fs` feature
 //!
 //! # Usage Examples
 //!


### PR DESCRIPTION
This fixes a broken link in the documentation