### PR TITLE
Expose a file_list API + VfsPath::as_filesystem

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -4,6 +4,7 @@ use crate::error::VfsErrorKind;
 use crate::{SeekAndRead, SeekAndWrite, VfsError, VfsMetadata, VfsPath, VfsResult};
 use std::fmt::Debug;
 use std::time::SystemTime;
+use std::collections::HashSet;
 
 /// File system implementations must implement this trait
 /// All path parameters are absolute, starting with '/', except for the root directory
@@ -56,6 +57,10 @@ pub trait FileSystem: Debug + Sync + Send + 'static {
     }
     /// Moves the src directory to the destination path within the same filesystem (optional)
     fn move_dir(&self, _src: &str, _dest: &str) -> VfsResult<()> {
+        Err(VfsErrorKind::NotSupported.into())
+    }
+    /// Returns the file list as bare files (e.g. /init.luau, /foo/bar.luau)
+    fn file_list(&self) -> VfsResult<HashSet<String>> {
         Err(VfsErrorKind::NotSupported.into())
     }
 }

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -6,7 +6,7 @@ use crate::{SeekAndRead, VfsMetadata};
 use crate::{SeekAndWrite, VfsResult};
 use core::cmp;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashSet, HashMap};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
@@ -304,6 +304,11 @@ impl FileSystem for MemoryFS {
             .remove(path)
             .ok_or(VfsErrorKind::FileNotFound)?;
         Ok(())
+    }
+
+    fn file_list(&self) -> VfsResult<HashSet<String>> { 
+        let handle = self.handle.read().unwrap();
+        Ok(handle.files.keys().map(|x| x.to_string()).collect())
     }
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -107,8 +107,9 @@ pub struct VfsMetadata {
 }
 
 #[derive(Debug)]
-struct VFS {
-    fs: Box<dyn FileSystem>,
+pub struct VFS {
+    /// Inner filesystem
+    pub fs: Box<dyn FileSystem>,
 }
 
 /// A virtual filesystem path, identifying a single file or directory in this virtual filesystem
@@ -160,6 +161,11 @@ impl VfsPath {
     /// ````
     pub fn as_str(&self) -> &str {
         &self.path
+    }
+
+    /// Returns the inner filesystem from the VfsPath
+    pub fn as_filesystem(&self) -> &VFS {
+        &self.fs
     }
 
     /// Appends a path segment to this path, returning the result


### PR DESCRIPTION
file_list is really useful for my usecase of updating an in memory filesystem from a hashmap and may be useful for other cases as well. For now, this is only implemented in in-memory FS where it can be done quickly (and could be optimized even further in future). VfsPath::as_filesystem is useful for extracting out the filesystem from a VfsPath