### PR TITLE
Optimize memory allocations when joining paths

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -49,7 +49,11 @@ pub(crate) trait PathLike: Clone {
         if path.is_empty() {
             return Ok(in_path.to_string());
         }
-        let mut new_components: Vec<&str> = vec![];
+        let mut new_components: Vec<&str> = Vec::with_capacity(
+            in_path.chars().filter(|c| *c == '/').count()
+                + path.chars().filter(|c| *c == '/').count()
+                + 1,
+        );
         let mut base_path = if path.starts_with('/') {
             "".to_string()
         } else {
@@ -74,9 +78,15 @@ pub(crate) trait PathLike: Clone {
             }
         }
         let mut path = base_path;
+        path.reserve(
+            new_components.len()
+                + new_components
+                    .iter()
+                    .fold(0, |accum, part| accum + part.len()),
+        );
         for component in new_components {
-            path += "/";
-            path += component
+            path.push('/');
+            path.push_str(component);
         }
         Ok(path)
     }


### PR DESCRIPTION
In my application I have about 170k filesystem nodes and to do filtering over the filesystem I needed to iterate each node, test if it was a file or directory, and do some logic depending on the answer.

This entire operation would take upwards of 10 seconds (not hard timed, just going off feeling here) and seemed a bit unacceptable so I took a perf trace: https://share.firefox.dev/3Sycqjb

You can see in the second thread that there is a lot of time spent in `vfs::path::PathLike::join_internal()`:

![CleanShot 2025-05-09 at 13 51 59@2x](https://github.com/user-attachments/assets/580f1e35-7d97-4f8b-8182-dc9fc8f8b92d)

Which is partially caused by two separate allocation points that cause re-allocations of containers (note there's a `push_str()` on the left side as well):

![CleanShot 2025-05-09 at 13 52 25@2x](https://github.com/user-attachments/assets/5fdbcbb1-1f39-4ede-91c6-7abb10a525d7)

This PR optimizes these containers to have the required number of elements pre-allocated, which should reduce both overall memory consumed to be exactly what's required _and_ prevent constant re-allocation.

After applying the changes in this PR, the perf now looks like this: https://share.firefox.dev/3ZasPy1

![CleanShot 2025-05-09 at 13 55 14@2x](https://github.com/user-attachments/assets/41b76de6-3382-4535-b46e-22c458b99d77)

And the allocations are hardly even present in the trace

![CleanShot 2025-05-09 at 13 55 44@2x](https://github.com/user-attachments/assets/216d6109-521b-4560-8ad0-2436f9b4f5d1)