### PR TITLE
fix(logging): Remove stray println

### DIFF
--- a/src/async_vfs/path.rs
+++ b/src/async_vfs/path.rs
@@ -247,12 +247,9 @@ impl AsyncVfsPath {
                     err.with_path(&self.path)
                         .with_context(|| "Could not read directory")
                 })?
-                .map(move |path| {
-                    println!("{:?}", path);
-                    AsyncVfsPath {
-                        path: format!("{}/{}", parent, path),
-                        fs: fs.clone(),
-                    }
+                .map(move |path| AsyncVfsPath {
+                    path: format!("{}/{}", parent, path),
+                    fs: fs.clone(),
                 }),
         ))
     }


### PR DESCRIPTION
There was a stray `println!` here which was printing when attempting a read operation which I assume was accidental.