### PR TITLE
Fix spelling error

### DIFF
--- a/src/async_vfs/test_macros.rs
+++ b/src/async_vfs/test_macros.rs
@@ -503,7 +503,7 @@ macro_rules! test_async_vfs {
 
                 /// Utility function for templating the same error message
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(
@@ -1245,7 +1245,7 @@ macro_rules! test_async_vfs_readonly {
                 /// Utility function for templating the same error message
                 // TODO: Maybe deduplicate this function
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ impl From<VfsErrorKind> for VfsError {
             //              never forgets to add a path. Might need a separate error type for FS impls vs VFS
             path: "PATH NOT FILLED BY VFS LAYER".into(),
             kind,
-            context: "An error occured".into(),
+            context: "An error occurred".into(),
             cause: None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -182,7 +182,7 @@ mod tests {
         let result = produce_anyhow_result().unwrap_err();
         assert_eq!(
             result.to_string(),
-            "An error occured for 'foo': FileSystem error: Not a file"
+            "An error occurred for 'foo': FileSystem error: Not a file"
         )
     }
 }

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -524,7 +524,7 @@ use super::*;
 
                 /// Utility function for templating the same error message
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(
@@ -1260,7 +1260,7 @@ macro_rules! test_vfs_readonly {
                 /// Utility function for templating the same error message
                 // TODO: Maybe deduplicate this function
                 fn invalid_path_message(path: &str) -> String {
-                    format!("An error occured for '{}': The path is invalid", path)
+                    format!("An error occurred for '{}': The path is invalid", path)
                 }
 
                 assert_eq!(


### PR DESCRIPTION
Change "occured" to "occurred" in error.rs as well as corresponding tests.