### PR TITLE
feat: abstract async-vfs implementation for wider runtime compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,13 +10,14 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -40,47 +26,41 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1da3ae8dabd9c00f453a329dfe1fb28da3c0a72e2478cdcd93171740c20499"
 dependencies = [
- "async-lock",
+ "async-lock 2.8.0",
  "async-task",
  "concurrent-queue",
- "fastrand 2.0.1",
- "futures-lite",
+ "fastrand",
+ "futures-lite 1.13.0",
  "slab",
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.3.1"
+name = "async-fs"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
+ "async-lock 3.4.2",
  "blocking",
- "futures-lite",
- "once_cell",
+ "futures-lite 2.0.0",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.13.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
  "autocfg",
  "cfg-if",
  "concurrent-queue",
- "futures-lite",
- "log",
+ "futures-io",
+ "futures-lite 2.0.0",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
- "socket2",
- "waker-fn",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -89,7 +69,47 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite 2.0.0",
+]
+
+[[package]]
+name = "async-process"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451e3cf68011bd56771c79db04a9e333095ab6349f7e47592b788e9b98720cc8"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock 3.4.2",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite 2.0.0",
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -104,29 +124,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-std"
-version = "1.12.0"
+name = "async-signal"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
- "async-channel",
- "async-global-executor",
  "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
+ "async-lock 3.4.2",
+ "atomic-waker",
+ "cfg-if",
  "futures-core",
  "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
+ "rustix 1.1.4",
+ "signal-hook-registry",
  "slab",
- "wasm-bindgen-futures",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -181,25 +193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -212,25 +215,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.4.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c36a4d0d48574b3dd360b4b7d95cc651d2b6557b6402848a27d4b228a473e2a"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
- "async-lock",
  "async-task",
- "fastrand 2.0.1",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.0.0",
  "piper",
- "tracing",
 ]
-
-[[package]]
-name = "bumpalo"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytes"
@@ -245,15 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 
 [[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,9 +246,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -305,12 +290,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -320,12 +305,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
+name = "event-listener"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
- "instant",
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -400,7 +397,17 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand 1.9.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1155db57329dca6d018b61e76b1488ce9a2e5e44028cac420a5898f4fcef63"
+dependencies = [
+ "fastrand",
  "futures-core",
  "futures-io",
  "memchr",
@@ -472,117 +479,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "log"
-version = "0.4.20"
+name = "linux-raw-sys"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-dependencies = [
- "value-bag",
-]
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "object"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking"
@@ -609,24 +533,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.1",
+ "fastrand",
  "futures-io",
 ]
 
 [[package]]
 name = "polling"
-version = "2.8.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "autocfg",
- "bitflags",
  "cfg-if",
  "concurrent-queue",
- "libc",
- "log",
+ "hermit-abi",
  "pin-project-lite",
- "windows-sys 0.48.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -700,7 +622,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -738,23 +660,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
+name = "rustix"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustix"
-version = "0.37.25"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
- "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -778,6 +706,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,13 +725,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.4.9"
+name = "smol"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
- "libc",
- "winapi",
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock 3.4.2",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite 2.0.0",
 ]
 
 [[package]]
@@ -809,21 +754,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.29.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
- "autocfg",
- "backtrace",
  "pin-project-lite",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -855,20 +798,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.39"
+name = "tokio-util"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
  "pin-project-lite",
- "tracing-core",
+ "tokio",
 ]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "typenum"
@@ -892,12 +833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,15 +843,19 @@ name = "vfs"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "async-fs",
+ "async-lock 3.4.2",
  "async-recursion",
- "async-std",
  "async-trait",
+ "blocking",
  "camino",
  "filetime",
  "futures",
  "rust-embed",
+ "smol",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "uuid",
 ]
 
@@ -941,82 +880,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "winapi"
@@ -1050,13 +913,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1064,22 +924,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -1088,20 +942,14 @@ version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1111,21 +959,9 @@ checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1135,21 +971,9 @@ checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1159,21 +983,9 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,24 +15,35 @@ travis-ci = { repository = "manuel-woelker/rust-vfs", branch = "master" }
 
 [dependencies]
 rust-embed = { version = "8.0.0", optional = true }
-async-std = { version = "1.12.0", optional = true }
-async-trait = { version = "0.1.73", optional = true}
-tokio = { version = "1.29.0", features = ["macros", "rt"], optional = true}
-futures = {version = "0.3.28", optional = true}
-async-recursion = {version = "1.0.5", optional = true}
+async-trait = { version = "0.1.73", optional = true }
+futures = { version = "0.3.28", optional = true }
+async-recursion = { version = "1.0.5", optional = true }
+async-lock = { version = "3.4.2", optional = true }
 filetime = "0.2.23"
 camino = { version = "1.0.5", optional = true }
+
+# For tokio-based physical FS
+tokio = { version = "1.29.0", features = ["macros", "rt", "fs"], optional = true }
+tokio-util = { version = "0.7.18", features = ["compat"], optional = true }
+
+# For smol/async-std compatible physical FS
+async-fs = { version = "2.2.0", optional = true }
+blocking = { version = "1.6.2", optional = true, default-features = false }
 
 [dev-dependencies]
 uuid = { version = "=0.8.1", features = ["v4"] }
 camino = "1.0.5"
 anyhow = "1.0.58"
 tokio-test = "0.4.3"
+tokio = { version = "1.29.0", features = ["macros", "rt-multi-thread"] }
+smol = "2.0.2"
 
 [features]
 embedded-fs = ["rust-embed"]
-async-vfs = ["tokio", "async-std", "async-trait", "futures", "async-recursion"]
+async-vfs = ["async-trait", "futures", "async-recursion", "async-lock"]
+tokio-physical = ["async-vfs", "tokio", "tokio-util"]
+smol-physical = ["async-vfs", "async-fs", "blocking"]
 export-test-macros = [ "camino" ]
 
 [package.metadata.docs.rs]
-features = ["embedded-fs", "async-vfs"]
+features = ["embedded-fs", "async-vfs", "tokio-physical"]

--- a/src/async_vfs/filesystem.rs
+++ b/src/async_vfs/filesystem.rs
@@ -4,9 +4,9 @@ use crate::async_vfs::{AsyncVfsPath, SeekAndRead};
 use crate::error::VfsErrorKind;
 use crate::{VfsError, VfsMetadata, VfsResult};
 
-use async_std::io::Write;
-use async_std::stream::Stream;
 use async_trait::async_trait;
+use futures::io::AsyncWrite;
+use futures::stream::Stream;
 use std::fmt::Debug;
 use std::time::SystemTime;
 
@@ -32,9 +32,9 @@ pub trait AsyncFileSystem: Debug + Sync + Send + 'static {
     /// Opens the file at this path for reading
     async fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send + Unpin>>;
     /// Creates a file at this path for writing
-    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>>;
+    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>>;
     /// Opens the file at this path for appending
-    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>>;
+    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>>;
     /// Returns the file metadata for the file at this path
     async fn metadata(&self, path: &str) -> VfsResult<VfsMetadata>;
     /// Sets the files creation timestamp, if the implementation supports it

--- a/src/async_vfs/impls/altroot.rs
+++ b/src/async_vfs/impls/altroot.rs
@@ -4,8 +4,8 @@ use crate::async_vfs::{AsyncFileSystem, AsyncVfsPath, SeekAndRead};
 use crate::{error::VfsErrorKind, VfsMetadata, VfsResult};
 use std::time::SystemTime;
 
-use async_std::io::Write;
 use async_trait::async_trait;
+use futures::io::AsyncWrite;
 use futures::stream::{Stream, StreamExt};
 
 /// Similar to a chroot but done purely by path manipulation
@@ -60,11 +60,11 @@ impl AsyncFileSystem for AsyncAltrootFS {
         self.path(path)?.open_file().await
     }
 
-    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         self.path(path)?.create_file().await
     }
 
-    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         self.path(path)?.append_file().await
     }
 
@@ -131,22 +131,21 @@ mod tests {
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "tokio-physical", feature = "smol-physical"))]
 mod tests_physical {
     use super::*;
     use crate::async_vfs::AsyncPhysicalFS;
 
-    use async_std::io::ReadExt;
-
-    test_async_vfs!(futures::executor::block_on(async {
+    test_async_vfs!({
         let temp_dir = std::env::temp_dir();
         let dir = temp_dir.join(uuid::Uuid::new_v4().to_string());
         std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(dir.join("altroot")).unwrap();
 
         let physical_root: AsyncVfsPath = AsyncPhysicalFS::new(dir).into();
         let altroot_path = physical_root.join("altroot").unwrap();
-        altroot_path.create_dir().await.unwrap();
         AsyncAltrootFS::new(altroot_path)
-    }));
+    });
 
     test_async_vfs_readonly!({
         let physical_root: AsyncVfsPath = AsyncPhysicalFS::new("test").into();

--- a/src/async_vfs/impls/memory.rs
+++ b/src/async_vfs/impls/memory.rs
@@ -4,9 +4,8 @@ use crate::error::VfsErrorKind;
 use crate::path::VfsFileType;
 use crate::{VfsMetadata, VfsResult};
 
-use async_std::io::{prelude::SeekExt, Cursor, Read, Seek, SeekFrom, Write};
-use async_std::sync::{Arc, RwLock};
-use async_trait::async_trait;
+use async_lock::RwLock;
+use futures::io::{AsyncSeekExt, AsyncWrite, Cursor, SeekFrom};
 use futures::task::{Context, Poll};
 use futures::{Stream, StreamExt};
 use std::collections::hash_map::Entry;
@@ -15,6 +14,9 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::mem::swap;
 use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
 
 type AsyncMemoryFsHandle = Arc<RwLock<AsyncMemoryFsImpl>>;
 
@@ -60,29 +62,23 @@ struct AsyncWritableFile {
     fs: AsyncMemoryFsHandle,
 }
 
-impl Write for AsyncWritableFile {
+impl AsyncWrite for AsyncWritableFile {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> Poll<Result<usize, async_std::io::Error>> {
+    ) -> Poll<Result<usize, std::io::Error>> {
         let this = self.get_mut();
         let file = Pin::new(&mut this.content);
         file.poll_write(cx, buf)
     }
     // Flush any bytes left in the write buffer to the virtual file
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), async_std::io::Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
         let this = self.get_mut();
         let file = Pin::new(&mut this.content);
         file.poll_flush(cx)
     }
-    fn poll_close(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), async_std::io::Error>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
         let this = self.get_mut();
         let file = Pin::new(&mut this.content);
         file.poll_close(cx)
@@ -116,12 +112,12 @@ impl AsyncReadableFile {
     }
 }
 
-impl Read for AsyncReadableFile {
+impl futures::io::AsyncRead for AsyncReadableFile {
     fn poll_read(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<Result<usize, async_std::io::Error>> {
+    ) -> Poll<Result<usize, std::io::Error>> {
         let this = self.get_mut();
         let bytes_left = this.len() - this.cursor_pos;
         let bytes_read = std::cmp::min(buf.len() as u64, bytes_left);
@@ -136,12 +132,12 @@ impl Read for AsyncReadableFile {
     }
 }
 
-impl Seek for AsyncReadableFile {
+impl futures::io::AsyncSeek for AsyncReadableFile {
     fn poll_seek(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
         pos: SeekFrom,
-    ) -> Poll<Result<u64, async_std::io::Error>> {
+    ) -> Poll<Result<u64, std::io::Error>> {
         let this = self.get_mut();
         let new_pos = match pos {
             SeekFrom::Start(offset) => offset as i64,
@@ -149,8 +145,8 @@ impl Seek for AsyncReadableFile {
             SeekFrom::Current(offset) => this.cursor_pos as i64 + offset,
         };
         if new_pos < 0 || new_pos >= this.len() as i64 {
-            Poll::Ready(Err(async_std::io::Error::new(
-                async_std::io::ErrorKind::InvalidData,
+            Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
                 "Requested offset is outside the file!",
             )))
         } else {
@@ -226,7 +222,7 @@ impl AsyncFileSystem for AsyncMemoryFS {
         }))
     }
 
-    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         self.ensure_has_parent(path).await?;
         let content = Arc::new(Vec::<u8>::new());
         self.handle.write().await.files.insert(
@@ -244,7 +240,7 @@ impl AsyncFileSystem for AsyncMemoryFS {
         Ok(Box::new(writer))
     }
 
-    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         let handle = self.handle.write().await;
         let file = handle.files.get(path).ok_or(VfsErrorKind::FileNotFound)?;
         let mut content = Cursor::new(file.content.as_ref().clone());
@@ -323,11 +319,18 @@ struct AsyncMemoryFile {
     content: Arc<Vec<u8>>,
 }
 
+fn ensure_file(file: &AsyncMemoryFile) -> VfsResult<()> {
+    if file.file_type != VfsFileType::File {
+        return Err(VfsErrorKind::Other("Not a file".into()).into());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::async_vfs::AsyncVfsPath;
-    use async_std::io::{ReadExt, WriteExt};
+    use futures::io::{AsyncReadExt, AsyncWriteExt};
     test_async_vfs!(AsyncMemoryFS::new());
 
     #[tokio::test]
@@ -337,8 +340,8 @@ mod tests {
         let _send = &path as &dyn Send;
         {
             let mut file = path.create_file().await.unwrap();
-            write!(file, "Hello world").await.unwrap();
-            write!(file, "!").await.unwrap();
+            file.write_all(b"Hello world").await.unwrap();
+            file.write_all(b"!").await.unwrap();
         }
         {
             let mut file = path.open_file().await.unwrap();
@@ -357,7 +360,6 @@ mod tests {
     #[tokio::test]
     async fn append_file() {
         let root = AsyncVfsPath::new(AsyncMemoryFS::new());
-        let _string = String::new();
         let path = root.join("test_append.txt").unwrap();
         path.create_file()
             .await
@@ -382,7 +384,6 @@ mod tests {
     #[tokio::test]
     async fn create_dir() {
         let root = AsyncVfsPath::new(AsyncMemoryFS::new());
-        let _string = String::new();
         let path = root.join("foo").unwrap();
         path.create_dir().await.unwrap();
         let metadata = path.metadata().await.unwrap();
@@ -427,11 +428,4 @@ mod tests {
         assert_eq!(&dest.read_to_string().await?, "Hello World");
         Ok(())
     }
-}
-
-fn ensure_file(file: &AsyncMemoryFile) -> VfsResult<()> {
-    if file.file_type != VfsFileType::File {
-        return Err(VfsErrorKind::Other("Not a file".into()).into());
-    }
-    Ok(())
 }

--- a/src/async_vfs/impls/mod.rs
+++ b/src/async_vfs/impls/mod.rs
@@ -3,4 +3,16 @@
 pub mod altroot;
 pub mod memory;
 pub mod overlay;
+
+#[cfg(all(feature = "tokio-physical", feature = "smol-physical"))]
+compile_error!(
+    "Features `tokio-physical` and `smol-physical` are mutually exclusive. Please enable only one."
+);
+
+#[cfg(feature = "tokio-physical")]
+#[path = "physical_tokio.rs"]
+pub mod physical;
+
+#[cfg(all(feature = "smol-physical", not(feature = "tokio-physical")))]
+#[path = "physical_smol.rs"]
 pub mod physical;

--- a/src/async_vfs/impls/overlay.rs
+++ b/src/async_vfs/impls/overlay.rs
@@ -4,8 +4,8 @@ use crate::async_vfs::{AsyncFileSystem, AsyncVfsPath, SeekAndRead};
 use crate::error::VfsErrorKind;
 use crate::{VfsMetadata, VfsResult};
 
-use async_std::io::Write;
 use async_trait::async_trait;
+use futures::io::AsyncWrite;
 use futures::stream::{Stream, StreamExt};
 use std::collections::HashSet;
 use std::time::SystemTime;
@@ -132,7 +132,7 @@ impl AsyncFileSystem for AsyncOverlayFS {
         self.read_path(path).await?.open_file().await
     }
 
-    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         self.ensure_has_parent(path).await?;
         let result = self.write_path(path)?.create_file().await?;
         let whiteout_path = self.whiteout_path(path)?;
@@ -142,7 +142,7 @@ impl AsyncFileSystem for AsyncOverlayFS {
         Ok(result)
     }
 
-    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         let write_path = self.write_path(path)?;
         if !write_path.exists().await? {
             self.ensure_has_parent(path).await?;
@@ -214,7 +214,7 @@ mod tests {
     use super::*;
     use crate::async_vfs::AsyncMemoryFS;
 
-    use async_std::io::WriteExt;
+    use futures::io::AsyncWriteExt;
     use futures::stream::StreamExt;
 
     test_async_vfs!({
@@ -428,20 +428,21 @@ mod tests {
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "tokio-physical", feature = "smol-physical"))]
 mod tests_physical {
     use super::*;
     use crate::async_vfs::AsyncPhysicalFS;
 
-    test_async_vfs!(futures::executor::block_on(async {
+    test_async_vfs!({
         let temp_dir = std::env::temp_dir();
         let dir = temp_dir.join(uuid::Uuid::new_v4().to_string());
         let lower_path = dir.join("lower");
-        async_std::fs::create_dir_all(&lower_path).await.unwrap();
+        std::fs::create_dir_all(&lower_path).unwrap();
         let upper_path = dir.join("upper");
-        async_std::fs::create_dir_all(&upper_path).await.unwrap();
+        std::fs::create_dir_all(&upper_path).unwrap();
 
         let upper_root: AsyncVfsPath = AsyncPhysicalFS::new(upper_path).into();
         let lower_root: AsyncVfsPath = AsyncPhysicalFS::new(lower_path).into();
         AsyncOverlayFS::new(&[upper_root, lower_root])
-    }));
+    });
 }

--- a/src/async_vfs/impls/physical_smol.rs
+++ b/src/async_vfs/impls/physical_smol.rs
@@ -1,20 +1,19 @@
-//! An async implementation of a "physical" file system implementation using the underlying OS file system
+//! An async implementation of a "physical" file system using smol/async-fs
 use crate::async_vfs::{AsyncFileSystem, SeekAndRead};
 use crate::error::VfsErrorKind;
 use crate::path::VfsFileType;
 use crate::{VfsError, VfsMetadata, VfsResult};
 
-use async_std::fs::{File, OpenOptions};
-use async_std::io::{ErrorKind, Write};
-use async_std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use filetime::FileTime;
+use futures::io::AsyncWrite;
 use futures::stream::{Stream, StreamExt};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::time::SystemTime;
-use tokio::runtime::Handle;
 
-/// A physical filesystem implementation using the underlying OS file system
+/// A physical filesystem implementation using smol/async-fs for async I/O
 #[derive(Debug)]
 pub struct AsyncPhysicalFS {
     root: Pin<PathBuf>,
@@ -36,28 +35,13 @@ impl AsyncPhysicalFS {
     }
 }
 
-/// Runs normal blocking io on a tokio thread.
-/// Requires a tokio runtime.
+/// Runs normal blocking io on a smol thread.
 async fn blocking_io<F>(f: F) -> Result<(), VfsError>
 where
     F: FnOnce() -> std::io::Result<()> + Send + 'static,
 {
-    if Handle::try_current().is_ok() {
-        let result = tokio::task::spawn_blocking(f).await;
-
-        match result {
-            Ok(val) => val,
-            Err(err) => {
-                return Err(VfsError::from(VfsErrorKind::Other(format!(
-                    "Tokio Concurrency Error: {err}"
-                ))));
-            }
-        }?;
-
-        Ok(())
-    } else {
-        Err(VfsError::from(VfsErrorKind::NotSupported))
-    }
+    blocking::unblock(f).await.map_err(VfsError::from)?;
+    Ok(())
 }
 
 #[async_trait]
@@ -66,22 +50,21 @@ impl AsyncFileSystem for AsyncPhysicalFS {
         &self,
         path: &str,
     ) -> VfsResult<Box<dyn Unpin + Stream<Item = String> + Send>> {
-        let entries = Box::new(
-            self.get_path(path)
-                .read_dir()
-                .await?
-                .map(|entry| entry.unwrap().file_name().into_string().unwrap()),
-        );
-        Ok(entries)
+        let entries: Vec<String> = async_fs::read_dir(self.get_path(path))
+            .await?
+            .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+            .collect()
+            .await;
+        Ok(Box::new(futures::stream::iter(entries)))
     }
 
     async fn create_dir(&self, path: &str) -> VfsResult<()> {
         let fs_path = self.get_path(path);
-        match async_std::fs::create_dir(&fs_path).await {
+        match async_fs::create_dir(&fs_path).await {
             Ok(()) => Ok(()),
             Err(e) => match e.kind() {
                 ErrorKind::AlreadyExists => {
-                    let metadata = async_std::fs::metadata(&fs_path).await.unwrap();
+                    let metadata = async_fs::metadata(&fs_path).await.unwrap();
                     if metadata.is_dir() {
                         return Err(VfsError::from(VfsErrorKind::DirectoryExists));
                     }
@@ -93,16 +76,16 @@ impl AsyncFileSystem for AsyncPhysicalFS {
     }
 
     async fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send + Unpin>> {
-        Ok(Box::new(File::open(self.get_path(path)).await?))
+        Ok(Box::new(async_fs::File::open(self.get_path(path)).await?))
     }
 
-    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
-        Ok(Box::new(File::create(self.get_path(path)).await?))
+    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
+        Ok(Box::new(async_fs::File::create(self.get_path(path)).await?))
     }
 
-    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         Ok(Box::new(
-            OpenOptions::new()
+            async_fs::OpenOptions::new()
                 .write(true)
                 .append(true)
                 .open(self.get_path(path))
@@ -111,7 +94,7 @@ impl AsyncFileSystem for AsyncPhysicalFS {
     }
 
     async fn metadata(&self, path: &str) -> VfsResult<VfsMetadata> {
-        let metadata = self.get_path(path).metadata().await?;
+        let metadata = async_fs::metadata(self.get_path(path)).await?;
         Ok(if metadata.is_dir() {
             VfsMetadata {
                 file_type: VfsFileType::Directory,
@@ -148,32 +131,32 @@ impl AsyncFileSystem for AsyncPhysicalFS {
     }
 
     async fn exists(&self, path: &str) -> VfsResult<bool> {
-        Ok(self.get_path(path).exists().await)
+        Ok(self.get_path(path).exists())
     }
 
     async fn remove_file(&self, path: &str) -> VfsResult<()> {
-        async_std::fs::remove_file(self.get_path(path)).await?;
+        async_fs::remove_file(self.get_path(path)).await?;
         Ok(())
     }
 
     async fn remove_dir(&self, path: &str) -> VfsResult<()> {
-        async_std::fs::remove_dir(self.get_path(path)).await?;
+        async_fs::remove_dir(self.get_path(path)).await?;
         Ok(())
     }
 
     async fn copy_file(&self, src: &str, dest: &str) -> VfsResult<()> {
-        async_std::fs::copy(self.get_path(src), self.get_path(dest)).await?;
+        async_fs::copy(self.get_path(src), self.get_path(dest)).await?;
         Ok(())
     }
 
     async fn move_file(&self, src: &str, dest: &str) -> VfsResult<()> {
-        async_std::fs::rename(self.get_path(src), self.get_path(dest)).await?;
+        async_fs::rename(self.get_path(src), self.get_path(dest)).await?;
 
         Ok(())
     }
 
     async fn move_dir(&self, src: &str, dest: &str) -> VfsResult<()> {
-        let result = async_std::fs::rename(self.get_path(src), self.get_path(dest)).await;
+        let result = async_fs::rename(self.get_path(src), self.get_path(dest)).await;
         if result.is_err() {
             // Error possibly due to different filesystems, return not supported and let the fallback handle it
             return Err(VfsErrorKind::NotSupported.into());
@@ -187,17 +170,15 @@ mod tests {
     use super::*;
     use crate::async_vfs::AsyncVfsPath;
 
-    use async_std::io::ReadExt;
-    use async_std::io::WriteExt;
-    use async_std::path::Path;
+    use futures::io::{AsyncReadExt, AsyncWriteExt};
     use futures::stream::StreamExt;
 
-    test_async_vfs!(futures::executor::block_on(async {
+    test_async_vfs!({
         let temp_dir = std::env::temp_dir();
         let dir = temp_dir.join(uuid::Uuid::new_v4().to_string());
-        async_std::fs::create_dir_all(&dir).await.unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
         AsyncPhysicalFS::new(dir)
-    }));
+    });
     test_async_vfs_readonly!({ AsyncPhysicalFS::new("test/test_directory") });
 
     fn create_root() -> AsyncVfsPath {
@@ -206,7 +187,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_file() {
-        let expected = async_std::fs::read_to_string("Cargo.toml").await.unwrap();
+        let expected = std::fs::read_to_string("Cargo.toml").unwrap();
         let root = create_root();
         let mut string = String::new();
         root.join("Cargo.toml")
@@ -222,48 +203,33 @@ mod tests {
 
     #[tokio::test]
     async fn create_file() {
+        use crate::async_vfs::test_macros::write_file;
         let root = create_root();
-        let _string = String::new();
-        let _ = async_std::fs::remove_file("target/test.txt").await;
-        root.join("target/test.txt")
-            .unwrap()
-            .create_file()
-            .await
-            .unwrap()
-            .write_all(b"Testing only")
-            .await
-            .unwrap();
+        let _ = std::fs::remove_file("target/test.txt");
+        write_file(
+            root.join("target/test.txt").unwrap().create_file().await.unwrap(),
+            b"Testing only",
+        )
+        .await;
         let read = std::fs::read_to_string("target/test.txt").unwrap();
         assert_eq!(read, "Testing only");
     }
 
     #[tokio::test]
     async fn append_file() {
+        use crate::async_vfs::test_macros::write_file;
         let root = create_root();
-        let _string = String::new();
-        let _ = async_std::fs::remove_file("target/test_append.txt").await;
+        let _ = std::fs::remove_file("target/test_append.txt");
         let path = Box::pin(root.join("target/test_append.txt").unwrap());
-        path.create_file()
-            .await
-            .unwrap()
-            .write_all(b"Testing 1")
-            .await
-            .unwrap();
-        path.append_file()
-            .await
-            .unwrap()
-            .write_all(b"Testing 2")
-            .await
-            .unwrap();
-        let read = async_std::fs::read_to_string("target/test_append.txt")
-            .await
-            .unwrap();
+        write_file(path.create_file().await.unwrap(), b"Testing 1").await;
+        write_file(path.append_file().await.unwrap(), b"Testing 2").await;
+        let read = std::fs::read_to_string("target/test_append.txt").unwrap();
         assert_eq!(read, "Testing 1Testing 2");
     }
 
     #[tokio::test]
     async fn read_dir() {
-        let _expected = async_std::fs::read_to_string("Cargo.toml").await.unwrap();
+        let _expected = std::fs::read_to_string("Cargo.toml").unwrap();
         let root = create_root();
         let entries: Vec<_> = root.read_dir().await.unwrap().collect().await;
         let map: Vec<_> = entries
@@ -276,22 +242,22 @@ mod tests {
 
     #[tokio::test]
     async fn create_dir() {
-        let _ = async_std::fs::remove_dir("target/fs_test").await;
+        let _ = std::fs::remove_dir("target/fs_test_smol");
         let root = create_root();
-        root.join("target/fs_test")
+        root.join("target/fs_test_smol")
             .unwrap()
             .create_dir()
             .await
             .unwrap();
-        let path = Path::new("target/fs_test");
-        assert!(path.exists().await, "Path was not created");
-        assert!(path.is_dir().await, "Path is not a directory");
-        async_std::fs::remove_dir("target/fs_test").await.unwrap();
+        let path = std::path::Path::new("target/fs_test_smol");
+        assert!(path.exists(), "Path was not created");
+        assert!(path.is_dir(), "Path is not a directory");
+        std::fs::remove_dir("target/fs_test_smol").unwrap();
     }
 
     #[tokio::test]
     async fn file_metadata() {
-        let expected = async_std::fs::read_to_string("Cargo.toml").await.unwrap();
+        let expected = std::fs::read_to_string("Cargo.toml").unwrap();
         let root = create_root();
         let metadata = root.join("Cargo.toml").unwrap().metadata().await.unwrap();
         assert_eq!(metadata.len, expected.len() as u64);

--- a/src/async_vfs/impls/physical_tokio.rs
+++ b/src/async_vfs/impls/physical_tokio.rs
@@ -1,0 +1,289 @@
+//! An async implementation of a "physical" file system using tokio
+use crate::async_vfs::{AsyncFileSystem, SeekAndRead};
+use crate::error::VfsErrorKind;
+use crate::path::VfsFileType;
+use crate::{VfsError, VfsMetadata, VfsResult};
+
+use async_trait::async_trait;
+use filetime::FileTime;
+use futures::io::AsyncWrite;
+use futures::stream::Stream;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::SystemTime;
+use tokio::runtime::Handle;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+/// A physical filesystem implementation using tokio for async I/O
+#[derive(Debug)]
+pub struct AsyncPhysicalFS {
+    root: Pin<PathBuf>,
+}
+
+impl AsyncPhysicalFS {
+    /// Create a new physical filesystem rooted in `root`
+    pub fn new<T: AsRef<Path>>(root: T) -> Self {
+        AsyncPhysicalFS {
+            root: Pin::new(root.as_ref().to_path_buf()),
+        }
+    }
+
+    fn get_path(&self, mut path: &str) -> PathBuf {
+        if path.starts_with('/') {
+            path = &path[1..];
+        }
+        self.root.join(path)
+    }
+}
+
+/// Runs normal blocking io on a tokio thread.
+/// Requires a tokio runtime.
+async fn blocking_io<F>(f: F) -> Result<(), VfsError>
+where
+    F: FnOnce() -> std::io::Result<()> + Send + 'static,
+{
+    if Handle::try_current().is_ok() {
+        tokio::task::spawn_blocking(f)
+            .await
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+            .map_err(VfsError::from)
+    } else {
+        Err(VfsError::from(VfsErrorKind::NotSupported))
+    }
+}
+
+#[async_trait]
+impl AsyncFileSystem for AsyncPhysicalFS {
+    async fn read_dir(
+        &self,
+        path: &str,
+    ) -> VfsResult<Box<dyn Unpin + Stream<Item = String> + Send>> {
+        let mut read_dir = tokio::fs::read_dir(self.get_path(path)).await?;
+        let mut entries = Vec::new();
+        while let Some(entry) = read_dir.next_entry().await? {
+            entries.push(entry.file_name().into_string().unwrap());
+        }
+        Ok(Box::new(futures::stream::iter(entries)))
+    }
+
+    async fn create_dir(&self, path: &str) -> VfsResult<()> {
+        let fs_path = self.get_path(path);
+        match tokio::fs::create_dir(&fs_path).await {
+            Ok(()) => Ok(()),
+            Err(e) => match e.kind() {
+                ErrorKind::AlreadyExists => {
+                    let metadata = tokio::fs::metadata(&fs_path).await.unwrap();
+                    if metadata.is_dir() {
+                        return Err(VfsError::from(VfsErrorKind::DirectoryExists));
+                    }
+                    Err(VfsError::from(VfsErrorKind::FileExists))
+                }
+                _ => Err(e.into()),
+            },
+        }
+    }
+
+    async fn open_file(&self, path: &str) -> VfsResult<Box<dyn SeekAndRead + Send + Unpin>> {
+        let file = tokio::fs::File::open(self.get_path(path)).await?;
+        Ok(Box::new(file.compat()))
+    }
+
+    async fn create_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
+        let file = tokio::fs::File::create(self.get_path(path)).await?;
+        Ok(Box::new(file.compat_write()))
+    }
+
+    async fn append_file(&self, path: &str) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
+        let file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(self.get_path(path))
+            .await?;
+        Ok(Box::new(file.compat_write()))
+    }
+
+    async fn metadata(&self, path: &str) -> VfsResult<VfsMetadata> {
+        let metadata = tokio::fs::metadata(self.get_path(path)).await?;
+        Ok(if metadata.is_dir() {
+            VfsMetadata {
+                file_type: VfsFileType::Directory,
+                len: 0,
+                modified: metadata.modified().ok(),
+                created: metadata.created().ok(),
+                accessed: metadata.accessed().ok(),
+            }
+        } else {
+            VfsMetadata {
+                file_type: VfsFileType::File,
+                len: metadata.len(),
+                modified: metadata.modified().ok(),
+                created: metadata.created().ok(),
+                accessed: metadata.accessed().ok(),
+            }
+        })
+    }
+
+    async fn set_modification_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let path = self.get_path(path);
+
+        blocking_io(move || filetime::set_file_mtime(path, FileTime::from(time))).await?;
+
+        Ok(())
+    }
+
+    async fn set_access_time(&self, path: &str, time: SystemTime) -> VfsResult<()> {
+        let path = self.get_path(path);
+
+        blocking_io(move || filetime::set_file_atime(path, FileTime::from(time))).await?;
+
+        Ok(())
+    }
+
+    async fn exists(&self, path: &str) -> VfsResult<bool> {
+        Ok(tokio::fs::try_exists(self.get_path(path))
+            .await
+            .unwrap_or(false))
+    }
+
+    async fn remove_file(&self, path: &str) -> VfsResult<()> {
+        tokio::fs::remove_file(self.get_path(path)).await?;
+        Ok(())
+    }
+
+    async fn remove_dir(&self, path: &str) -> VfsResult<()> {
+        tokio::fs::remove_dir(self.get_path(path)).await?;
+        Ok(())
+    }
+
+    async fn copy_file(&self, src: &str, dest: &str) -> VfsResult<()> {
+        tokio::fs::copy(self.get_path(src), self.get_path(dest)).await?;
+        Ok(())
+    }
+
+    async fn move_file(&self, src: &str, dest: &str) -> VfsResult<()> {
+        tokio::fs::rename(self.get_path(src), self.get_path(dest)).await?;
+
+        Ok(())
+    }
+
+    async fn move_dir(&self, src: &str, dest: &str) -> VfsResult<()> {
+        let result = tokio::fs::rename(self.get_path(src), self.get_path(dest)).await;
+        if result.is_err() {
+            // Error possibly due to different filesystems, return not supported and let the fallback handle it
+            return Err(VfsErrorKind::NotSupported.into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_vfs::AsyncVfsPath;
+
+    use futures::io::{AsyncReadExt, AsyncWriteExt};
+    use futures::stream::StreamExt;
+
+    test_async_vfs!({
+        let temp_dir = std::env::temp_dir();
+        let dir = temp_dir.join(uuid::Uuid::new_v4().to_string());
+        std::fs::create_dir_all(&dir).unwrap();
+        AsyncPhysicalFS::new(dir)
+    });
+    test_async_vfs_readonly!({ AsyncPhysicalFS::new("test/test_directory") });
+
+    fn create_root() -> AsyncVfsPath {
+        AsyncPhysicalFS::new(std::env::current_dir().unwrap()).into()
+    }
+
+    #[tokio::test]
+    async fn open_file() {
+        let expected = std::fs::read_to_string("Cargo.toml").unwrap();
+        let root = create_root();
+        let mut string = String::new();
+        root.join("Cargo.toml")
+            .unwrap()
+            .open_file()
+            .await
+            .unwrap()
+            .read_to_string(&mut string)
+            .await
+            .unwrap();
+        assert_eq!(string, expected);
+    }
+
+    #[tokio::test]
+    async fn create_file() {
+        use crate::async_vfs::test_macros::write_file;
+        let root = create_root();
+        let _ = std::fs::remove_file("target/test.txt");
+        write_file(
+            root.join("target/test.txt").unwrap().create_file().await.unwrap(),
+            b"Testing only",
+        )
+        .await;
+        let read = std::fs::read_to_string("target/test.txt").unwrap();
+        assert_eq!(read, "Testing only");
+    }
+
+    #[tokio::test]
+    async fn append_file() {
+        use crate::async_vfs::test_macros::write_file;
+        let root = create_root();
+        let _ = std::fs::remove_file("target/test_append.txt");
+        let path = Box::pin(root.join("target/test_append.txt").unwrap());
+        write_file(path.create_file().await.unwrap(), b"Testing 1").await;
+        write_file(path.append_file().await.unwrap(), b"Testing 2").await;
+        let read = std::fs::read_to_string("target/test_append.txt").unwrap();
+        assert_eq!(read, "Testing 1Testing 2");
+    }
+
+    #[tokio::test]
+    async fn read_dir() {
+        let _expected = std::fs::read_to_string("Cargo.toml").unwrap();
+        let root = create_root();
+        let entries: Vec<_> = root.read_dir().await.unwrap().collect().await;
+        let map: Vec<_> = entries
+            .iter()
+            .map(|path: &AsyncVfsPath| path.as_str())
+            .filter(|x| x.ends_with(".toml"))
+            .collect();
+        assert_eq!(&["/Cargo.toml"], &map[..]);
+    }
+
+    #[tokio::test]
+    async fn create_dir() {
+        let _ = std::fs::remove_dir("target/fs_test");
+        let root = create_root();
+        root.join("target/fs_test")
+            .unwrap()
+            .create_dir()
+            .await
+            .unwrap();
+        let path = std::path::Path::new("target/fs_test");
+        assert!(path.exists(), "Path was not created");
+        assert!(path.is_dir(), "Path is not a directory");
+        std::fs::remove_dir("target/fs_test").unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_metadata() {
+        let expected = std::fs::read_to_string("Cargo.toml").unwrap();
+        let root = create_root();
+        let metadata = root.join("Cargo.toml").unwrap().metadata().await.unwrap();
+        assert_eq!(metadata.len, expected.len() as u64);
+        assert_eq!(metadata.file_type, VfsFileType::File);
+    }
+
+    #[tokio::test]
+    async fn dir_metadata() {
+        let root = create_root();
+        let metadata = root.metadata().await.unwrap();
+        assert_eq!(metadata.len, 0);
+        assert_eq!(metadata.file_type, VfsFileType::Directory);
+        let metadata = root.join("src").unwrap().metadata().await.unwrap();
+        assert_eq!(metadata.len, 0);
+        assert_eq!(metadata.file_type, VfsFileType::Directory);
+    }
+}

--- a/src/async_vfs/mod.rs
+++ b/src/async_vfs/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! This module currently has the following asynchronous file system implementations:
 //!
-//!  * **[`AsyncPhysicalFS`](impls/physical/struct.AsyncPhysicalFS.html)** - the actual filesystem of the underlying OS
+//!  * **[`AsyncPhysicalFS`](impls/physical/struct.AsyncPhysicalFS.html)** - the actual filesystem of the underlying OS (requires `tokio-physical` or `smol-physical` feature)
 //!  * **[`AsyncMemoryFS`](impls/memory/struct.AsyncMemoryFS.html)** - an ephemeral in-memory implementation (intended for unit tests)
 //!  * **[`AsyncAltrootFS`](impls/altroot/struct.AsyncAltrootFS.html)** - a file system with its root in a particular directory of another filesystem
 //!  * **[`AsyncOverlayFS`](impls/overlay/struct.AsyncOverlayFS.html)** - a union file system consisting of a read/writable upper layer and several read-only lower layers
@@ -13,23 +13,7 @@
 //! # Usage Examples
 //!
 //! ```
-//! use async_std::io::{ReadExt, WriteExt};
-//! use vfs::async_vfs::{AsyncVfsPath, AsyncPhysicalFS};
-//! use vfs::VfsError;
-//!
-//! # tokio_test::block_on(async {
-//! let root: AsyncVfsPath = AsyncPhysicalFS::new(std::env::current_dir().unwrap()).into();
-//! assert!(root.exists().await?);
-//!
-//! let mut content = String::new();
-//! root.join("README.md")?.open_file().await?.read_to_string(&mut content).await?;
-//! assert!(content.contains("vfs"));
-//! # Ok::<(), VfsError>(())
-//! # });
-//! ```
-//!
-//! ```
-//! use async_std::io::{ReadExt, WriteExt};
+//! use futures::io::{AsyncReadExt, AsyncWriteExt};
 //! use vfs::async_vfs::{AsyncVfsPath, AsyncMemoryFS};
 //! use vfs::VfsError;
 //!
@@ -60,5 +44,6 @@ pub use filesystem::AsyncFileSystem;
 pub use impls::altroot::AsyncAltrootFS;
 pub use impls::memory::AsyncMemoryFS;
 pub use impls::overlay::AsyncOverlayFS;
+#[cfg(any(feature = "tokio-physical", feature = "smol-physical"))]
 pub use impls::physical::AsyncPhysicalFS;
 pub use path::*;

--- a/src/async_vfs/path.rs
+++ b/src/async_vfs/path.rs
@@ -10,17 +10,17 @@ use crate::path::VfsFileType;
 use crate::{VfsMetadata, VfsResult};
 
 use async_recursion::async_recursion;
-use async_std::io::{Read, ReadExt, Seek, Write};
-use async_std::sync::Arc;
-use async_std::task::{Context, Poll};
+use futures::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncWrite};
 use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::SystemTime;
 
-/// Trait combining Seek and Read, return value for opening files
-pub trait SeekAndRead: Seek + Read {}
+/// Trait combining AsyncSeek and AsyncRead, return value for opening files
+pub trait SeekAndRead: AsyncSeek + AsyncRead {}
 
-impl<T> SeekAndRead for T where T: Seek + Read {}
+impl<T> SeekAndRead for T where T: AsyncSeek + AsyncRead {}
 
 #[derive(Debug)]
 struct AsyncVFS {
@@ -52,8 +52,8 @@ impl AsyncVfsPath {
     /// Creates a root path for the given filesystem
     ///
     /// ```
-    /// # use vfs::async_vfs::{AsyncPhysicalFS, AsyncVfsPath};
-    /// let path = AsyncVfsPath::new(AsyncPhysicalFS::new("."));
+    /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
+    /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// ````
     pub fn new<T: AsyncFileSystem>(filesystem: T) -> Self {
         AsyncVfsPath {
@@ -67,9 +67,9 @@ impl AsyncVfsPath {
     /// Returns the string representation of this path
     ///
     /// ```
-    /// # use vfs::async_vfs::{AsyncPhysicalFS, AsyncVfsPath};
+    /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
-    /// let path = AsyncVfsPath::new(AsyncPhysicalFS::new("."));
+    /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     ///
     /// assert_eq!(path.as_str(), "");
     /// assert_eq!(path.join("foo.txt")?.as_str(), "/foo.txt");
@@ -82,9 +82,9 @@ impl AsyncVfsPath {
     /// Appends a path segment to this path, returning the result
     ///
     /// ```
-    /// # use vfs::async_vfs::{AsyncPhysicalFS, AsyncVfsPath};
+    /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
-    /// let path = AsyncVfsPath::new(AsyncPhysicalFS::new("."));
+    /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     ///
     /// assert_eq!(path.join("foo.txt")?.as_str(), "/foo.txt");
     /// assert_eq!(path.join("foo/bar.txt")?.as_str(), "/foo/bar.txt");
@@ -259,12 +259,12 @@ impl AsyncVfsPath {
     /// ```
     /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
-    /// use async_std::io:: {ReadExt, WriteExt};
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
     ///
-    /// write!(file.create_file().await?, "Hello, world!").await?;
+    /// file.create_file().await?.write_all(b"Hello, world!").await?;
     ///
     /// let mut result = String::new();
     /// file.open_file().await?.read_to_string(&mut result).await?;
@@ -272,7 +272,7 @@ impl AsyncVfsPath {
     /// # Ok::<(), VfsError>(())
     /// # });
     /// ```
-    pub async fn create_file(&self) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    pub async fn create_file(&self) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         self.get_parent("create file").await?;
         self.fs.fs.create_file(&self.path).await.map_err(|err| {
             err.with_path(&self.path)
@@ -285,11 +285,11 @@ impl AsyncVfsPath {
     /// ```
     /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
-    /// use async_std::io:: {ReadExt, WriteExt};
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
-    /// write!(file.create_file().await?, "Hello, world!").await?;
+    /// file.create_file().await?.write_all(b"Hello, world!").await?;
     /// let mut result = String::new();
     ///
     /// file.open_file().await?.read_to_string(&mut result).await?;
@@ -329,19 +329,19 @@ impl AsyncVfsPath {
     /// ```
     /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
-    /// use async_std::io:: {ReadExt, WriteExt};
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
-    /// write!(file.create_file().await?, "Hello, ").await?;
-    /// write!(file.append_file().await?, "world!").await?;
+    /// file.create_file().await?.write_all(b"Hello, ").await?;
+    /// file.append_file().await?.write_all(b"world!").await?;
     /// let mut result = String::new();
     /// file.open_file().await?.read_to_string(&mut result).await?;
     /// assert_eq!(&result, "Hello, world!");
     /// # Ok::<(), VfsError>(())
     /// # });
     /// ```
-    pub async fn append_file(&self) -> VfsResult<Box<dyn Write + Send + Unpin>> {
+    pub async fn append_file(&self) -> VfsResult<Box<dyn AsyncWrite + Send + Unpin>> {
         self.fs.fs.append_file(&self.path).await.map_err(|err| {
             err.with_path(&self.path)
                 .with_context(|| "Could not open file for appending")
@@ -351,13 +351,13 @@ impl AsyncVfsPath {
     /// Removes the file at this path
     ///
     /// ```
-    /// use async_std::io:: {ReadExt, WriteExt};
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
     /// # use vfs::async_vfs::{AsyncMemoryFS , AsyncVfsPath};
     /// # use vfs::VfsError;
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
-    /// write!(file.create_file().await?, "Hello, ").await?;
+    /// file.create_file().await?.write_all(b"Hello, ").await?;
     /// assert!(file.exists().await?);
     ///
     /// file.remove_file().await?;
@@ -440,7 +440,7 @@ impl AsyncVfsPath {
     /// ```
     /// use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// use vfs::{VfsError, VfsFileType, VfsMetadata};
-    /// use async_std::io::WriteExt;
+    /// use futures::io::AsyncWriteExt;
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let directory = path.join("foo")?;
@@ -450,7 +450,7 @@ impl AsyncVfsPath {
     /// assert_eq!(directory.metadata().await?.file_type, VfsFileType::Directory);
     ///
     /// let file = path.join("bar.txt")?;
-    /// write!(file.create_file().await?, "Hello, world!").await?;
+    /// file.create_file().await?.write_all(b"Hello, world!").await?;
     ///
     /// assert_eq!(file.metadata().await?.len, 13);
     /// assert_eq!(file.metadata().await?.file_type, VfsFileType::File);
@@ -468,7 +468,7 @@ impl AsyncVfsPath {
     /// ```
     /// use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// use vfs::{VfsError, VfsFileType, VfsMetadata, VfsPath};
-    /// use async_std::io::WriteExt;
+    /// use futures::io::AsyncWriteExt;
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
@@ -498,7 +498,7 @@ impl AsyncVfsPath {
     /// ```
     /// use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// use vfs::{VfsError, VfsFileType, VfsMetadata, VfsPath};
-    /// use async_std::io::WriteExt;
+    /// use futures::io::AsyncWriteExt;
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
@@ -528,7 +528,7 @@ impl AsyncVfsPath {
     /// ```
     /// use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// use vfs::{VfsError, VfsFileType, VfsMetadata, VfsPath};
-    /// use async_std::io::WriteExt;
+    /// use futures::io::AsyncWriteExt;
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
@@ -722,11 +722,11 @@ impl AsyncVfsPath {
     /// ```
     /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
-    /// use async_std::io::{ReadExt, WriteExt};
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let file = path.join("foo.txt")?;
-    /// write!(file.create_file().await?, "Hello, world!").await?;
+    /// file.create_file().await?.write_all(b"Hello, world!").await?;
     ///
     /// let result = file.read_to_string().await?;
     ///
@@ -761,13 +761,13 @@ impl AsyncVfsPath {
     /// The destination must not exist, but its parent directory must
     ///
     /// ```
-    /// use async_std::io::{ReadExt, WriteExt};
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
     /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let src = path.join("foo.txt")?;
-    /// write!(src.create_file().await?, "Hello, world!").await?;
+    /// src.create_file().await?.write_all(b"Hello, world!").await?;
     /// let dest = path.join("bar.txt")?;
     ///
     /// src.copy_file(&dest).await?;
@@ -798,7 +798,7 @@ impl AsyncVfsPath {
             }
             let mut src = self.open_file().await?;
             let mut dest = destination.create_file().await?;
-            async_std::io::copy(&mut src, &mut dest)
+            futures::io::copy(&mut src, &mut dest)
                 .await
                 .map_err(|source| {
                     VfsError::from(source)
@@ -827,11 +827,11 @@ impl AsyncVfsPath {
     /// ```
     /// # use vfs::async_vfs::{AsyncMemoryFS, AsyncVfsPath};
     /// # use vfs::VfsError;
-    /// use async_std::io::{ReadExt, WriteExt};
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
     /// # tokio_test::block_on(async {
     /// let path = AsyncVfsPath::new(AsyncMemoryFS::new());
     /// let src = path.join("foo.txt")?;
-    /// write!(src.create_file().await?, "Hello, world!").await?;
+    /// src.create_file().await?.write_all(b"Hello, world!").await?;
     /// let dest = path.join("bar.txt")?;
     ///
     /// src.move_file(&dest).await?;
@@ -863,7 +863,7 @@ impl AsyncVfsPath {
             }
             let mut src = self.open_file().await?;
             let mut dest = destination.create_file().await?;
-            async_std::io::copy(&mut src, &mut dest)
+            futures::io::copy(&mut src, &mut dest)
                 .await
                 .map_err(|source| {
                     VfsError::from(source)

--- a/src/async_vfs/test_macros.rs
+++ b/src/async_vfs/test_macros.rs
@@ -1,3 +1,29 @@
+use crate::VfsResult;
+use futures::io::AsyncWriteExt;
+
+/// Helper to write data to an async writer and properly close it.
+/// Explicit close is required because futures::io::AsyncWrite does not
+/// guarantee flush on drop, unlike std::io::Write.
+pub async fn write_file(
+    mut writer: Box<dyn futures::io::AsyncWrite + Send + Unpin>,
+    data: &[u8],
+) {
+    writer.write_all(data).await.unwrap();
+    writer.close().await.unwrap();
+}
+
+/// Helper to write data to an async writer and properly close it, propagating errors.
+/// Explicit close is required because futures::io::AsyncWrite does not
+/// guarantee flush on drop, unlike std::io::Write.
+pub async fn try_write_file(
+    mut writer: Box<dyn futures::io::AsyncWrite + Send + Unpin>,
+    data: &[u8],
+) -> VfsResult<()> {
+    writer.write_all(data).await?;
+    writer.close().await?;
+    Ok(())
+}
+
 /// Run basic read/write vfs test to check for conformance
 /// If an Filesystem implementation is read-only use [test_async_vfs_readonly!] instead
 #[macro_export]
@@ -8,10 +34,11 @@ macro_rules! test_async_vfs {
             use super::*;
             use $crate::VfsFileType;
             use $crate::async_vfs::AsyncVfsPath;
+            use $crate::async_vfs::test_macros::{write_file, try_write_file};
             use $crate::VfsResult;
             use $crate::error::VfsErrorKind;
             use futures::stream::StreamExt;
-            use async_std::io::{WriteExt, ReadExt};
+            use futures::io::{AsyncWriteExt, AsyncReadExt};
             use std::time::SystemTime;
 
             fn create_root() -> AsyncVfsPath {
@@ -102,8 +129,9 @@ macro_rules! test_async_vfs {
                 let _send = &path as &dyn Send;
                 {
                     let mut file = path.create_file().await.unwrap();
-                    write!(file, "Hello world").await.unwrap();
-                    write!(file, "!").await.unwrap();
+                    file.write_all(b"Hello world").await.unwrap();
+                    file.write_all(b"!").await.unwrap();
+                    file.close().await.unwrap();
                 }
                 {
                     let mut file = path.open_file().await.unwrap();
@@ -123,8 +151,8 @@ macro_rules! test_async_vfs {
             async fn append_file() {
                 let root = create_root();
                 let path = root.join("test_append.txt").unwrap();
-                path.create_file().await.unwrap().write_all(b"Testing 1").await.unwrap();
-                path.append_file().await.unwrap().write_all(b"Testing 2").await.unwrap();
+                write_file(path.create_file().await.unwrap(), b"Testing 1").await;
+                write_file(path.append_file().await.unwrap(), b"Testing 2").await;
                 {
                     let mut file = path.open_file().await.unwrap();
                     let mut string: String = String::new();
@@ -153,7 +181,6 @@ macro_rules! test_async_vfs {
             #[tokio::test]
             async fn create_dir() {
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join("foo").unwrap();
                 path.create_dir().await.unwrap();
                 let metadata = path.metadata().await.unwrap();
@@ -164,7 +191,6 @@ macro_rules! test_async_vfs {
             #[tokio::test]
             async fn create_dir_with_camino() {
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join(camino::Utf8Path::new("foo")).unwrap();
                 path.create_dir().await.unwrap();
                 let metadata = path.metadata().await.unwrap();
@@ -175,7 +201,6 @@ macro_rules! test_async_vfs {
             #[tokio::test]
             async fn create_dir_all() -> VfsResult<()>{
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join("foo").unwrap();
                 path.create_dir().await.unwrap();
                 let path = root.join("foo/bar/baz").unwrap();
@@ -193,7 +218,6 @@ macro_rules! test_async_vfs {
             #[tokio::test]
             async fn create_dir_all_should_fail_for_existing_file() -> VfsResult<()>{
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join("foo").unwrap();
                 let path2 = root.join("foo/bar").unwrap();
                 path.create_file().await.unwrap();
@@ -219,7 +243,6 @@ macro_rules! test_async_vfs {
             #[tokio::test]
             async fn read_dir() {
                 let root = create_root();
-                let _string = String::new();
                 root.join("foo/bar/biz").unwrap().create_dir_all().await.unwrap();
                 root.join("baz").unwrap().create_file().await.unwrap();
                 root.join("foo/fizz").unwrap().create_file().await.unwrap();
@@ -643,7 +666,7 @@ macro_rules! test_async_vfs {
             async fn read_to_string() -> VfsResult<()> {
                 let root = create_root();
                 let path = root.join("foobar.txt")?;
-                path.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(path.create_file().await?, b"Hello World").await?;
                 assert_eq!(path.read_to_string().await?, "Hello World");
                 Ok(())
             }
@@ -677,7 +700,7 @@ macro_rules! test_async_vfs {
             async fn read_to_string_nonutf8() -> VfsResult<()> {
                 let root = create_root();
                 let path = root.join("foobar.txt")?;
-                path.create_file().await?.write_all(&vec![0, 159, 146, 150]).await?;
+                try_write_file(path.create_file().await?, &[0, 159, 146, 150]).await?;
                 let error_message = path.read_to_string().await.expect_err("read_to_string").to_string();
                 assert_eq!(
                     &error_message,
@@ -691,7 +714,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
                 src.copy_file(&dest).await?;
                 assert_eq!(&dest.read_to_string().await?, "Hello World");
                 Ok(())
@@ -717,8 +740,8 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
-                dest.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
+                try_write_file(dest.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.copy_file(&dest).await.expect_err("copy_file").to_string();
                 assert!(
@@ -734,7 +757,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("x/b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.copy_file(&dest).await.expect_err("copy_file").to_string();
                 assert!(
@@ -750,7 +773,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("a.txt/b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.copy_file(&dest).await.expect_err("copy_file").to_string();
                 assert!(
@@ -765,7 +788,7 @@ macro_rules! test_async_vfs {
             async fn copy_file_to_root() -> VfsResult<()> {
                 let root = create_root();
                 let src = root.join("a.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.copy_file(&root).await.expect_err("copy_file").to_string();
                 assert!(
@@ -781,7 +804,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
                 src.move_file(&dest).await?;
                 assert_eq!(&dest.read_to_string().await?, "Hello World");
                 assert!(!src.exists().await?, "Source should not exist anymore");
@@ -808,8 +831,8 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
-                dest.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
+                try_write_file(dest.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.move_file(&dest).await.expect_err("move_file").to_string();
                 assert!(
@@ -824,7 +847,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("x/b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.move_file(&dest).await.expect_err("copy_file").to_string();
                 assert!(
@@ -840,7 +863,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("a.txt")?;
                 let dest = root.join("a.txt/b.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.move_file(&dest).await.expect_err("copy_file").to_string();
                 assert!(
@@ -855,7 +878,7 @@ macro_rules! test_async_vfs {
             async fn move_file_to_root() -> VfsResult<()> {
                 let root = create_root();
                 let src = root.join("a.txt")?;
-                src.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.create_file().await?, b"Hello World").await?;
 
                 let error_message = src.move_file(&root).await.expect_err("copy_file").to_string();
                 assert!(
@@ -871,7 +894,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("foo")?;
                 src.join("bar/biz/fizz/buzz")?.create_dir_all().await?;
-                src.join("bar/baz.txt")?.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.join("bar/baz.txt")?.create_file().await?, b"Hello World").await?;
 
                 let dest = root.join("foo2")?;
                 assert_eq!(5, src.copy_dir(&dest).await?);
@@ -916,7 +939,7 @@ macro_rules! test_async_vfs {
                 let root = create_root();
                 let src = root.join("foo")?;
                 src.join("bar/biz/fizz/buzz")?.create_dir_all().await?;
-                src.join("bar/baz.txt")?.create_file().await?.write_all(b"Hello World").await?;
+                try_write_file(src.join("bar/baz.txt")?.create_file().await?, b"Hello World").await?;
 
                 let dest = root.join("foo2")?;
                 src.move_dir(&dest).await?;
@@ -997,6 +1020,7 @@ macro_rules! test_async_vfs_readonly {
         #[cfg(test)]
         mod vfs_tests_readonly {
             use super::*;
+            use futures::io::AsyncReadExt;
             use futures::stream::StreamExt;
             use $crate::async_vfs::AsyncVfsPath;
             use $crate::{VfsFileType, VfsResult};

--- a/src/impls/memory.rs
+++ b/src/impls/memory.rs
@@ -406,7 +406,6 @@ mod tests {
     #[test]
     fn append_file() {
         let root = VfsPath::new(MemoryFS::new());
-        let _string = String::new();
         let path = root.join("test_append.txt").unwrap();
         path.create_file().unwrap().write_all(b"Testing 1").unwrap();
         path.append_file().unwrap().write_all(b"Testing 2").unwrap();
@@ -421,7 +420,6 @@ mod tests {
     #[test]
     fn append_file_with_seek() {
         let root = VfsPath::new(MemoryFS::new());
-        let _string = String::new();
         let path = root.join("test_append.txt").unwrap();
         path.create_file().unwrap().write_all(b"Testing 1").unwrap();
         path.append_file().unwrap().write_all(b"Testing 2").unwrap();
@@ -441,7 +439,6 @@ mod tests {
     #[test]
     fn create_dir() {
         let root = VfsPath::new(MemoryFS::new());
-        let _string = String::new();
         let path = root.join("foo").unwrap();
         path.create_dir().unwrap();
         let metadata = path.metadata().unwrap();

--- a/src/impls/physical.rs
+++ b/src/impls/physical.rs
@@ -173,7 +173,6 @@ mod tests {
     #[test]
     fn create_file() {
         let root = create_root();
-        let _string = String::new();
         let _ = std::fs::remove_file("target/test.txt");
         root.join("target/test.txt")
             .unwrap()
@@ -188,7 +187,6 @@ mod tests {
     #[test]
     fn append_file() {
         let root = create_root();
-        let _string = String::new();
         let _ = std::fs::remove_file("target/test_append.txt");
         let path = root.join("target/test_append.txt").unwrap();
         path.create_file().unwrap().write_all(b"Testing 1").unwrap();

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -178,7 +178,6 @@ use super::*;
             #[test]
             fn create_dir() {
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join("foo").unwrap();
                 path.create_dir().unwrap();
                 let metadata = path.metadata().unwrap();
@@ -189,7 +188,6 @@ use super::*;
             #[test]
             fn create_dir_with_camino() {
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join(camino::Utf8Path::new("foo")).unwrap();
                 path.create_dir().unwrap();
                 let metadata = path.metadata().unwrap();
@@ -200,7 +198,6 @@ use super::*;
             #[test]
             fn create_dir_all() -> VfsResult<()>{
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join("foo").unwrap();
                 path.create_dir().unwrap();
                 let path = root.join("foo/bar/baz").unwrap();
@@ -218,7 +215,6 @@ use super::*;
             #[test]
             fn create_dir_all_should_fail_for_existing_file() -> VfsResult<()>{
                 let root = create_root();
-                let _string = String::new();
                 let path = root.join("foo").unwrap();
                 let path2 = root.join("foo/bar").unwrap();
                 path.create_file().unwrap();
@@ -244,7 +240,6 @@ use super::*;
             #[test]
             fn read_dir() {
                 let root = create_root();
-                let _string = String::new();
                 root.join("foo/bar/biz").unwrap().create_dir_all().unwrap();
                 root.join("baz").unwrap().create_file().unwrap();
                 root.join("foo/fizz").unwrap().create_file().unwrap();


### PR DESCRIPTION
Seems like I just missed the window for v0.13.0 which is a shame, but I wanted to put up a draft for my previous suggestion (https://github.com/manuel-woelker/rust-vfs/issues/77#issuecomment-3388365411) to abstract out the `async-vfs` feature in a manner that makes it runtime-agnostic.

**I'll note before going on:** This PR had LLM assistance. This description was written by me. I've contributed to this crate before and have built some libraries on top of it using my own brain, so I like to think I'm familiar enough with its internals to see if something the LLM spit out is crap. However, if this project wishes to remain free of any LLM code I'm happy to rewrite this by hand at some point.

## Context

My use-case for async is mostly for one of my libraries: [`enfusion_pak`](https://github.com/manuel-woelker/rust-vfs/tree/9189433daabe961d4fa6905f665e923235a812db). This library powers https://landaire.net/enfusion_tools, which allows for pure WASM reading of proprietary filesystem data from the Arma and DayZ games.

Strictly speaking, async _might not_ be required, but it makes things way easier considering the _only_ way to read data from a web browser is with async IO. The way I've implemented this library (and one other) is in a sans-io manner though because the total content of files can span into dozens of gigabytes, so although the VFS is populated with filesystem entries, I may never read any file data until a `VfsPath` kicks off the operation. At that point though I still try to keep memory usage low and avoid bringing the whole file into memory.

Anyways, trying to bridge sync <-> async sounds like a pain with WASM and I'd rather just keep things all async if I can, so I'm moderately invested in this feature.

This is in draft mode just to get some initial feedback. I've not yet wired this up into my own libraries to see how things play out, but things look positive from the tests.

## Implementation details

Some high-level notes:

- The `async-vfs` feature will add the minimal deps necessary for the abstracted async implementation
- I've ditched `async-std` entirely and added new `tokio-physical` and `smol-physical` features which give you the `AsyncPhysicalFS` with the enabled backend
- I've currently got this wired up so if you use tokio and smol features simultaneously, you'll get a compiler error. I don't think this is strictly necessary and the [cargo reference](https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features) suggests avoiding this if possible

As implemented, my old comment still stands true:

| Type/Trait | Alternative |
|-----------|------------|
| `Arc`        | `std::sync::Arc` |
| `async_io::io::Cursor` | `futures::io::Cursor` |
| `async_io::io::Read` | `futures::io::AsyncRead` |
| `async_io::sync::RwLock` | [`async_lock::RwLock`](https://crates.io/crates/async-lock) |
| `async_io::io::Seek` | `futures::io::AsyncSeek` |
| `async_io::io::SeekExt` | `futures::io::AsyncSeekExt` |
| `async_io::io::SeekFrom` | `futures::io::SeekFrom` |
| `async_io::io::Write` | `futures::io::AsyncWrite` |
| `async_io::stream::Stream` | `futures::stream::Stream` |

And ones that were not previously called out:

Type/Function | Used | Notes |
|---|---|---|
| `async_std::task::Context` | `std::task::Context` | `poll_next` in `WalkDirIterator` `Stream` impl |
| `async_std::task::Poll` | `std::task::Poll` | `poll_*` methods for custom `AsyncRead`/`AsyncWrite`/`AsyncSeek` impls |
| `async_std::io::copy` | `futures::io::copy` | Cross-filesystem `copy_file` and `move_file` |
| `async_std::fs::*` | `tokio::fs::*` or `async_fs::*` | Physical filesystem ops, feature-gated behind `tokio-physical` or `smol-physical` |
| *(new)* `tokio_util::compat` | `TokioAsyncReadCompatExt`, `TokioAsyncWriteCompatExt` | Bridges tokio's IO traits to `futures::io` in `physical_tokio.rs` |
| *(new)* `blocking::unblock` | `blocking::unblock` | Runs `filetime` ops off the async thread in `physical_smol.rs` |

Overall dependencies by feature (hopefully didn't miss anything):

Feature | Dependencies | Count |
|---|---|---|
| *(none)* | - cfg-if<br>- filetime<br>- libc | **3** |
| `async-vfs` | - async-lock<br>- async-recursion<br>- async-trait<br>- concurrent-queue<br>- crossbeam-utils<br>- event-listener<br>- event-listener-strategy<br>- futures<br>- futures-channel<br>- futures-core<br>- futures-executor<br>- futures-io<br>- futures-macro<br>- futures-sink<br>- futures-task<br>- futures-util<br>- memchr<br>- parking<br>- pin-project-lite<br>- pin-utils<br>- proc-macro2<br>- quote<br>- slab<br>- syn<br>- unicode-ident | **28** |
| `tokio-physical` | - bytes<br>- tokio<br>- tokio-macros<br>- tokio-util | **32** |
| `smol-physical` | - async-channel<br>- async-fs<br>- async-task<br>- atomic-waker<br>- blocking<br>- fastrand<br>- futures-lite<br>- piper<br>- waker-fn